### PR TITLE
feat: add embeddings-dynamic feature and musl static binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,20 @@ jobs:
             os: ubuntu-latest
             name: coraline-linux-x86_64
             use_cross: false
+          # Linux x86_64 (musl, fully static — works on older glibc)
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            name: coraline-linux-x86_64-musl
+            use_cross: true
           # Linux ARM64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             name: coraline-linux-aarch64
+            use_cross: true
+          # Linux ARM64 (musl, fully static — works on older glibc)
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            name: coraline-linux-aarch64-musl
             use_cross: true
           # macOS ARM64
           - target: aarch64-apple-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.3.1] - 2026-03-18
+
+### Added
+
+- **`embeddings-dynamic` feature flag** — alternative to `embeddings` that uses `ort/load-dynamic` instead of `ort/download-binaries`, allowing users on systems with older glibc (e.g., Rocky Linux, HPC nodes) to supply their own `libonnxruntime.so` built against their local glibc ([#8](https://github.com/greysquirr3l/coraline/issues/8))
+- **musl static binaries in releases** — `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets added to the release CI matrix, producing fully static binaries with zero glibc dependency
+
+---
+
 ## [0.3.0] - 2026-03-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ coraline embed --download
 
 > **Note:** Pre-built release binaries do **not** include the `embeddings` feature. Build from source if you need semantic search.
 
+#### Older Linux / HPC systems (glibc issues)
+
+If the standard `embeddings` feature fails to compile due to glibc incompatibility (e.g., Rocky Linux, CentOS, HPC nodes), use the `embeddings-dynamic` feature instead:
+
+```bash
+cargo install coraline --features embeddings-dynamic
+```
+
+This uses `ort/load-dynamic` — instead of bundling ONNX Runtime binaries, it loads `libonnxruntime.so` at runtime from your system. You must install or build ONNX Runtime separately and ensure it's on your library path (`LD_LIBRARY_PATH` or `/usr/local/lib`).
+
+Alternatively, download the **musl static binary** from the [Releases](https://github.com/greysquirr3l/coraline/releases) page — these have zero glibc dependency (but do not include embeddings support).
+
 ## 🚀 Quick Start
 
 ### 1. Initialize a Project

--- a/crates/coraline/Cargo.toml
+++ b/crates/coraline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coraline"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 description = "Coraline: semantic code knowledge graph for faster AI-assisted development."
@@ -31,7 +31,7 @@ regex = "1"
 globset = "0.4.18"
 rayon = "1"
 ndarray = { version = "0.17", optional = true }
-ort = { version = "=2.0.0-rc.11", features = ["download-binaries", "ndarray"], optional = true }
+ort = { version = "=2.0.0-rc.11", features = ["ndarray"], optional = true }
 tokenizers = { version = "0.21", default-features = false, features = ["onig"], optional = true }
 ureq = "3"
 
@@ -77,7 +77,8 @@ tree-sitter-swift = "0.7.1"
 tree-sitter-kotlin-ng = "1.1.0"  # Using -ng fork which is compatible with tree-sitter 0.26
 
 [features]
-embeddings = ["dep:ort", "dep:tokenizers", "dep:ndarray"]
+embeddings = ["dep:ort", "dep:tokenizers", "dep:ndarray", "ort/download-binaries"]
+embeddings-dynamic = ["dep:ort", "dep:tokenizers", "dep:ndarray", "ort/load-dynamic"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -11,7 +11,7 @@ use coraline::memory;
 use coraline::sync::GitHooksManager;
 use coraline::types::NodeKind;
 use coraline::types::{BuildContextOptions, ContextFormat, EdgeKind};
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 use coraline::vectors;
 use tracing::{debug, info};
 
@@ -42,9 +42,9 @@ enum Command {
     Config(ConfigArgs),
     Hooks(HooksArgs),
     Serve(ServeArgs),
-    #[cfg(feature = "embeddings")]
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
     Embed(EmbedArgs),
-    #[cfg(feature = "embeddings")]
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
     Model(ModelArgs),
 }
 
@@ -190,7 +190,7 @@ struct ServeArgs {
     mcp: bool,
 }
 
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 #[derive(Debug, Args)]
 struct EmbedArgs {
     /// Project root (defaults to current directory).
@@ -209,7 +209,7 @@ struct EmbedArgs {
     variant: String,
 }
 
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 #[derive(Debug, Args)]
 struct ModelArgs {
     #[arg(short = 'p', long = "path")]
@@ -221,7 +221,7 @@ struct ModelArgs {
     action: ModelAction,
 }
 
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 #[derive(Debug, Subcommand)]
 enum ModelAction {
     /// Download model files from `HuggingFace` (tokenizer + ONNX weights).
@@ -263,9 +263,9 @@ fn main() {
         Command::Config(a) => a.path.clone(),
         Command::Hooks(a) => a.path.clone(),
         Command::Serve(a) => a.path.clone(),
-        #[cfg(feature = "embeddings")]
+        #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Embed(a) => a.path.clone(),
-        #[cfg(feature = "embeddings")]
+        #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Model(a) => a.path.clone(),
         Command::Install => None,
     };
@@ -311,14 +311,14 @@ fn main() {
                 println!("Use --mcp to start the MCP server.");
             }
         }
-        #[cfg(feature = "embeddings")]
+        #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Embed(args) => run_embed(args),
-        #[cfg(feature = "embeddings")]
+        #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Model(args) => run_model(args),
     }
 }
 
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 fn run_model(args: ModelArgs) {
     let project_root = resolve_project_root(args.path);
     let cfg = config::load_toml_config(&project_root).unwrap_or_default();
@@ -364,7 +364,7 @@ fn run_model(args: ModelArgs) {
     }
 }
 
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 fn run_embed(args: EmbedArgs) {
     let project_root = resolve_project_root(args.path);
 

--- a/crates/coraline/src/lib.rs
+++ b/crates/coraline/src/lib.rs
@@ -15,7 +15,7 @@ pub mod sync;
 pub mod tools;
 pub mod types;
 pub mod utils;
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 pub mod vectors;
 
 #[derive(Debug, Default)]

--- a/crates/coraline/src/tools/file_tools.rs
+++ b/crates/coraline/src/tools/file_tools.rs
@@ -546,19 +546,19 @@ impl Tool for SyncTool {
 }
 
 /// Tool for semantic (vector) search over indexed nodes.
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 pub struct SemanticSearchTool {
     project_root: PathBuf,
 }
 
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 impl SemanticSearchTool {
     pub const fn new(project_root: PathBuf) -> Self {
         Self { project_root }
     }
 }
 
-#[cfg(feature = "embeddings")]
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 impl Tool for SemanticSearchTool {
     fn name(&self) -> &'static str {
         "coraline_semantic_search"

--- a/crates/coraline/src/tools/mod.rs
+++ b/crates/coraline/src/tools/mod.rs
@@ -206,9 +206,9 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
     }
 
     // Register semantic search only when at least one ONNX model variant is present.
-    #[cfg(feature = "embeddings")]
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
     let model_dir = crate::vectors::default_model_dir(project_root);
-    #[cfg(feature = "embeddings")]
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
     if crate::vectors::MODEL_PREFERENCE_ORDER
         .iter()
         .any(|name| model_dir.join(name).exists())


### PR DESCRIPTION
## Summary

Adds two paths for users on systems with older glibc (Rocky Linux, HPC nodes, etc.) to use coraline — addressing #8.

### Changes

**New `embeddings-dynamic` feature flag**
- Uses `ort/load-dynamic` instead of `ort/download-binaries`
- Users supply their own `libonnxruntime.so` built against their local glibc
- Same code paths, same functionality — just different ONNX Runtime linking strategy

**Musl static binaries in release CI**
- Added `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets
- Produces fully static binaries with zero glibc dependency
- Available from the Releases page on day one

**Updated docs**
- README: new section for older Linux / HPC systems
- CHANGELOG: v0.3.1 entry

### Testing

- `cargo check` — default, `embeddings`, and `embeddings-dynamic` all pass
- `cargo test --all-features` — 38/38 passing
- `cargo clippy --all-features -- -D warnings` — clean

Closes #8