### PR TITLE
chore: ignore aur/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ reference_projects/
 docs/dev/
 .coraline/
 .mypy_cache/
+aur/
 
 # Rust
 target/


### PR DESCRIPTION
Adds `aur/` to `.gitignore` so local AUR packaging files are not tracked in the repository.