### PR TITLE
fix(mcp): harden search parsing and tool alias dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **FTS5 search hardened against special-character queries** — search terms are now individually double-quoted before SQLite `MATCH` execution, with embedded quotes escaped; blank/whitespace-only input returns empty results instead of an FTS syntax error. Queries containing `/` (e.g. file paths), `"`, or other FTS special characters now work correctly
 - **MCP tool dispatch resolves prefixed tool names** — `ToolRegistry` now normalizes common client prefixes (`mcp_coraline_coraline_*`, `mcp_coraline_*`, `mcp_*`) before lookup, preventing `Unknown tool` errors when MCP clients such as VS Code Copilot automatically prefix registered tool names
+- **Removed `#[allow(clippy::cast_possible_truncation)]` suppressions** — all `u64 as usize` casts in MCP tool `execute` functions replaced with `usize::try_from().ok().unwrap_or(N)`; `f64 as f32` in `SemanticSearchTool` narrowed to a single line-level allow with justification comment
+- **Fixed silent empty-string return in `resolve_node_id`** — the `len() == 1` branch now returns a proper `internal_error` instead of silently producing an empty node ID if the iterator is unexpectedly exhausted
 - **Release workflow not triggered by auto-tag** — tags pushed by `github-actions[bot]` via `GITHUB_TOKEN` don't fire `push` events on other workflows; auto-tag now explicitly triggers the release workflow via `workflow_dispatch`
 
 ## [0.7.0] - 2026-04-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FTS5 search hardened against special-character queries** — search terms are now individually double-quoted before SQLite `MATCH` execution, with embedded quotes escaped; blank/whitespace-only input returns empty results instead of an FTS syntax error. Queries containing `/` (e.g. file paths), `"`, or other FTS special characters now work correctly
+- **MCP tool dispatch resolves prefixed tool names** — `ToolRegistry` now normalises common client prefixes (`mcp_coraline_coraline_*`, `mcp_coraline_*`, `mcp_*`) before lookup, preventing `Unknown tool` errors when MCP clients such as VS Code Copilot automatically prefix registered tool names
 - **Release workflow not triggered by auto-tag** — tags pushed by `github-actions[bot]` via `GITHUB_TOKEN` don't fire `push` events on other workflows; auto-tag now explicitly triggers the release workflow via `workflow_dispatch`
 
 ## [0.7.0] - 2026-04-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **FTS5 search hardened against special-character queries** — search terms are now individually double-quoted before SQLite `MATCH` execution, with embedded quotes escaped; blank/whitespace-only input returns empty results instead of an FTS syntax error. Queries containing `/` (e.g. file paths), `"`, or other FTS special characters now work correctly
-- **MCP tool dispatch resolves prefixed tool names** — `ToolRegistry` now normalises common client prefixes (`mcp_coraline_coraline_*`, `mcp_coraline_*`, `mcp_*`) before lookup, preventing `Unknown tool` errors when MCP clients such as VS Code Copilot automatically prefix registered tool names
+- **MCP tool dispatch resolves prefixed tool names** — `ToolRegistry` now normalizes common client prefixes (`mcp_coraline_coraline_*`, `mcp_coraline_*`, `mcp_*`) before lookup, preventing `Unknown tool` errors when MCP clients such as VS Code Copilot automatically prefix registered tool names
 - **Release workflow not triggered by auto-tag** — tags pushed by `github-actions[bot]` via `GITHUB_TOKEN` don't fire `push` events on other workflows; auto-tag now explicitly triggers the release workflow via `workflow_dispatch`
 
 ## [0.7.0] - 2026-04-13

--- a/crates/coraline/src/db.rs
+++ b/crates/coraline/src/db.rs
@@ -439,15 +439,8 @@ pub fn search_nodes(
     kind: Option<NodeKind>,
     limit: usize,
 ) -> std::io::Result<Vec<SearchResult>> {
-    // Use FTS5 for multi-word searches, or OR each word for better matching
-    // Example: "calculator functionality" -> search for nodes containing "calculator" OR "functionality"
-    let words: Vec<&str> = query.split_whitespace().collect();
-    let fts_query = if words.len() > 1 {
-        // Multi-word: OR search (any word matches)
-        words.join(" OR ")
-    } else {
-        // Single word: use as-is
-        query.to_string()
+    let Some(fts_query) = build_fts_query(query) else {
+        return Ok(Vec::new());
     };
 
     // First try FTS search for better matching
@@ -494,6 +487,22 @@ pub fn search_nodes(
     }
 
     Ok(results)
+}
+
+fn build_fts_query(query: &str) -> Option<String> {
+    let mut terms = query
+        .split_whitespace()
+        .filter(|term| !term.is_empty())
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")));
+
+    let first = terms.next()?;
+    let fts_query = terms.fold(first, |mut acc, term| {
+        acc.push_str(" OR ");
+        acc.push_str(&term);
+        acc
+    });
+
+    Some(fts_query)
 }
 
 pub fn find_nodes_by_name(conn: &Connection, name: &str) -> std::io::Result<Vec<Node>> {
@@ -885,4 +894,30 @@ fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<Edge> {
         line: row.get(4)?,
         column: row.get(5)?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_fts_query;
+
+    #[test]
+    fn build_fts_query_quotes_slash_terms() {
+        assert_eq!(
+            build_fts_query("/auth/login/2fa"),
+            Some("\"/auth/login/2fa\"".to_string())
+        );
+    }
+
+    #[test]
+    fn build_fts_query_escapes_embedded_quotes() {
+        assert_eq!(
+            build_fts_query("route \"name\""),
+            Some("\"route\" OR \"\"\"name\"\"\"".to_string())
+        );
+    }
+
+    #[test]
+    fn build_fts_query_returns_none_for_blank_input() {
+        assert_eq!(build_fts_query("   \n\t  "), None);
+    }
 }

--- a/crates/coraline/src/db.rs
+++ b/crates/coraline/src/db.rs
@@ -492,7 +492,6 @@ pub fn search_nodes(
 fn build_fts_query(query: &str) -> Option<String> {
     let mut terms = query
         .split_whitespace()
-        .filter(|term| !term.is_empty())
         .map(|term| format!("\"{}\"", term.replace('"', "\"\"")));
 
     let first = terms.next()?;
@@ -899,6 +898,7 @@ fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<Edge> {
 #[cfg(test)]
 mod tests {
     use super::build_fts_query;
+    use rusqlite::Connection;
 
     #[test]
     fn build_fts_query_quotes_slash_terms() {
@@ -919,5 +919,45 @@ mod tests {
     #[test]
     fn build_fts_query_returns_none_for_blank_input() {
         assert_eq!(build_fts_query("   \n\t  "), None);
+    }
+
+    #[test]
+    fn build_fts_query_executes_with_slash_and_quote_terms() {
+        let conn = Connection::open_in_memory();
+        assert!(conn.is_ok());
+        let Some(conn) = conn.ok() else {
+            return;
+        };
+
+        let create_result = conn.execute_batch(
+            "CREATE VIRTUAL TABLE nodes_fts USING fts5(name, qualified_name, docstring, content='');",
+        );
+        assert!(create_result.is_ok());
+
+        let insert_result = conn.execute(
+            "INSERT INTO nodes_fts(rowid, name, qualified_name, docstring) VALUES (1, ?1, ?2, ?3)",
+            ("auth_login_2fa", "/auth/login/2fa", "route \"name\""),
+        );
+        assert!(insert_result.is_ok());
+
+        let queries = ["/auth/login/2fa", "route \"name\""];
+        for raw in queries {
+            let fts_query = build_fts_query(raw);
+            assert!(fts_query.is_some());
+            let Some(fts_query) = fts_query else {
+                return;
+            };
+
+            let query_result: rusqlite::Result<i64> = conn.query_row(
+                "SELECT COUNT(*) FROM nodes_fts WHERE nodes_fts MATCH ?1",
+                [fts_query],
+                |row| row.get(0),
+            );
+
+            assert!(query_result.is_ok());
+            if let Ok(count) = query_result {
+                assert!(count >= 1);
+            }
+        }
     }
 }

--- a/crates/coraline/src/tools/file_tools.rs
+++ b/crates/coraline/src/tools/file_tools.rs
@@ -55,7 +55,6 @@ impl Tool for ReadFileTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let raw_path = params
             .get("path")
@@ -67,13 +66,15 @@ impl Tool for ReadFileTool {
         let start_line = params
             .get("start_line")
             .and_then(Value::as_u64)
-            .map_or(1, |n| n as usize)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(1)
             .max(1);
 
         let limit = params
             .get("limit")
             .and_then(Value::as_u64)
-            .map_or(200, |n| n as usize);
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(200);
 
         let text = std::fs::read_to_string(&path).map_err(|e| {
             ToolError::not_found(format!("Cannot read file {}: {e}", path.display()))
@@ -309,14 +310,17 @@ impl Tool for FindFileTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let pattern = params
             .get("pattern")
             .and_then(Value::as_str)
             .ok_or_else(|| ToolError::invalid_params("pattern must be a string"))?;
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(50);
 
         let is_glob = pattern.contains('*') || pattern.contains('?') || pattern.contains('[');
 
@@ -954,14 +958,18 @@ impl Tool for SemanticSearchTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let query = params
             .get("query")
             .and_then(Value::as_str)
             .ok_or_else(|| ToolError::invalid_params("query must be a string"))?;
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(10) as usize;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(10);
+        #[allow(clippy::cast_possible_truncation)] // f64→f32: no lossless conversion in std
         let min_similarity = params
             .get("min_similarity")
             .and_then(Value::as_f64)

--- a/crates/coraline/src/tools/graph_tools.rs
+++ b/crates/coraline/src/tools/graph_tools.rs
@@ -59,7 +59,6 @@ impl Tool for SearchTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let query = params
             .get("query")
@@ -80,7 +79,11 @@ impl Tool for SearchTool {
                 _ => None,
             });
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(10) as usize;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(10);
 
         let file_filter = params.get("file").and_then(Value::as_str);
 
@@ -182,14 +185,17 @@ impl Tool for CallersTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
 
         let node_id = resolve_node_id(&conn, &self.project_root, &params, "node_id")?;
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(20);
 
         // Get edges where this node is the target and edge kind is "calls"
         let edges = db::get_edges_by_target(&conn, &node_id, Some(EdgeKind::Calls), limit)
@@ -264,14 +270,17 @@ impl Tool for CalleesTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
 
         let node_id = resolve_node_id(&conn, &self.project_root, &params, "node_id")?;
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(20);
 
         // Get edges where this node is the source and edge kind is "calls"
         let edges = db::get_edges_by_source(&conn, &node_id, Some(EdgeKind::Calls), limit)
@@ -351,7 +360,6 @@ impl Tool for ImpactTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -361,11 +369,11 @@ impl Tool for ImpactTool {
         let max_depth = params
             .get("max_depth")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .and_then(|n| usize::try_from(n).ok());
         let max_nodes = params
             .get("max_nodes")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .and_then(|n| usize::try_from(n).ok());
 
         let traversal_options = TraversalOptions {
             max_depth,
@@ -475,7 +483,6 @@ impl Tool for FindSymbolTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let pattern = params
             .get("name_pattern")
@@ -492,7 +499,11 @@ impl Tool for FindSymbolTool {
             .and_then(Value::as_bool)
             .unwrap_or(false);
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(10) as usize;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(10);
 
         let file_filter = params.get("file").and_then(Value::as_str);
 
@@ -712,7 +723,6 @@ impl Tool for FindReferencesTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -731,7 +741,11 @@ impl Tool for FindReferencesTool {
                 _ => None,
             });
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(50);
 
         let edges = db::get_edges_by_target(&conn, &node_id, edge_kind, limit)
             .map_err(|e| ToolError::internal_error(format!("Failed to get edges: {e}")))?;
@@ -914,7 +928,6 @@ impl Tool for DependenciesTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -924,11 +937,11 @@ impl Tool for DependenciesTool {
         let depth = params
             .get("depth")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .and_then(|n| usize::try_from(n).ok());
         let limit = params
             .get("limit")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .and_then(|n| usize::try_from(n).ok());
 
         let options = TraversalOptions {
             max_depth: depth.or(Some(2)),
@@ -1031,7 +1044,6 @@ impl Tool for DependentsTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -1041,11 +1053,11 @@ impl Tool for DependentsTool {
         let depth = params
             .get("depth")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .and_then(|n| usize::try_from(n).ok());
         let limit = params
             .get("limit")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .and_then(|n| usize::try_from(n).ok());
 
         let options = TraversalOptions {
             max_depth: depth.or(Some(2)),
@@ -1154,7 +1166,6 @@ impl Tool for PathTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         use std::collections::{HashMap, VecDeque};
 
@@ -1193,7 +1204,11 @@ impl Tool for PathTool {
         };
         let to_id = resolve_node_id(&conn, &self.project_root, &to_params, "node_id")?;
 
-        let max_depth = params.get("max_depth").and_then(Value::as_u64).unwrap_or(6) as usize;
+        let max_depth = params
+            .get("max_depth")
+            .and_then(Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(6);
 
         // BFS following outgoing edges, recording parents for path reconstruction.
 
@@ -1431,10 +1446,11 @@ fn resolve_node_id(
             "No symbol named '{name}' found{}",
             file_hint.map_or_else(String::new, |f| format!(" in file '{f}'"))
         ))),
-        1 => Ok(candidates
+        1 => candidates
             .into_iter()
             .next()
-            .map_or_else(String::new, |n| n.id)),
+            .map(|n| n.id)
+            .ok_or_else(|| ToolError::internal_error("internal: candidate count mismatch")),
         _ => {
             let listing: Vec<String> = candidates
                 .iter()

--- a/crates/coraline/src/tools/mod.rs
+++ b/crates/coraline/src/tools/mod.rs
@@ -345,4 +345,13 @@ mod tests {
         let result = registry.execute("mcp_coraline_coraline_mock_tool", serde_json::json!({}));
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_registry_execute_mcp_coraline_single_prefix_tool_name() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(CoralineMockTool));
+
+        let result = registry.execute("mcp_coraline_mock_tool", serde_json::json!({}));
+        assert!(result.is_ok());
+    }
 }

--- a/crates/coraline/src/tools/mod.rs
+++ b/crates/coraline/src/tools/mod.rs
@@ -111,11 +111,31 @@ impl ToolRegistry {
 
     /// Execute a tool by name
     pub fn execute(&self, name: &str, params: Value) -> ToolResult {
-        self.get(name).map_or_else(
-            || Err(ToolError::not_found(format!("Tool not found: {name}"))),
-            |tool| tool.execute(params),
-        )
+        if let Some(tool) = self.get(name) {
+            return tool.execute(params);
+        }
+
+        if let Some(alias) = normalize_tool_name(name)
+            && let Some(tool) = self.get(&alias)
+        {
+            return tool.execute(params);
+        }
+
+        Err(ToolError::not_found(format!("Tool not found: {name}")))
     }
+}
+
+fn normalize_tool_name(name: &str) -> Option<String> {
+    const CORALINE_TOOL_PREFIXES: [&str; 2] = ["mcp_coraline_coraline_", "mcp_coraline_"];
+
+    for prefix in CORALINE_TOOL_PREFIXES {
+        if let Some(rest) = name.strip_prefix(prefix) {
+            return Some(format!("coraline_{rest}"));
+        }
+    }
+
+    name.strip_prefix("mcp_")
+        .map(std::string::ToString::to_string)
 }
 
 /// Create a default tool registry with all built-in tools
@@ -235,6 +255,7 @@ mod tests {
     use super::*;
 
     struct MockTool;
+    struct CoralineMockTool;
 
     impl Tool for MockTool {
         fn name(&self) -> &'static str {
@@ -243,6 +264,29 @@ mod tests {
 
         fn description(&self) -> &'static str {
             "A mock tool for testing"
+        }
+
+        fn input_schema(&self) -> Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                }
+            })
+        }
+
+        fn execute(&self, params: Value) -> ToolResult {
+            Ok(serde_json::json!({ "result": params }))
+        }
+    }
+
+    impl Tool for CoralineMockTool {
+        fn name(&self) -> &'static str {
+            "coraline_mock_tool"
+        }
+
+        fn description(&self) -> &'static str {
+            "A coraline-prefixed mock tool for testing"
         }
 
         fn input_schema(&self) -> Value {
@@ -282,5 +326,23 @@ mod tests {
         let registry = ToolRegistry::new();
         let result = registry.execute("nonexistent", serde_json::json!({}));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_registry_execute_mcp_prefixed_tool_name() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(MockTool));
+
+        let result = registry.execute("mcp_mock_tool", serde_json::json!({ "value": "test" }));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_registry_execute_mcp_coraline_prefixed_tool_name() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(CoralineMockTool));
+
+        let result = registry.execute("mcp_coraline_coraline_mock_tool", serde_json::json!({}));
+        assert!(result.is_ok());
     }
 }

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -8,7 +8,7 @@ Protocol notes:
 - Expects `notifications/initialized` after `initialize` before normal requests
 - `tools/list` supports pagination via `cursor` and `nextCursor`
 
-`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. All other 26 tools are always available.
+`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. The remaining 26 tools are typically available; memory-backed tools may be skipped if their initialization fails (e.g. due to filesystem or permission issues).
 
 ### Background Auto-Sync
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -8,7 +8,7 @@ Protocol notes:
 - Expects `notifications/initialized` after `initialize` before normal requests
 - `tools/list` supports pagination via `cursor` and `nextCursor`
 
-`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. All other 25 tools are always available.
+`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. All other 26 tools are always available.
 
 ### Background Auto-Sync
 
@@ -389,9 +389,9 @@ Read the contents of a file within the project.
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `file_path` | string | ✅ | — | File path (relative or absolute) |
-| `start_line` | number | | — | Start line (1-based, inclusive) |
-| `end_line` | number | | — | End line (1-based, inclusive) |
+| `path` | string | ✅ | — | File path (relative to project root or absolute) |
+| `start_line` | number | | `1` | First line to read (1-indexed, inclusive) |
+| `limit` | number | | `200` | Maximum number of lines to return |
 
 ---
 
@@ -403,8 +403,7 @@ List the contents of a directory within the project.
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `path` | string | | `.` | Directory path (relative or absolute) |
-| `recursive` | boolean | | `false` | Recurse into subdirectories |
+| `path` | string | | `.` | Directory path (relative to project root or absolute). Defaults to project root. |
 
 ---
 


### PR DESCRIPTION
## Summary
This PR fixes two MCP reliability issues reported in:
- #31
- #30 (partial follow-up context; this PR addresses the MCP/tooling half)

### 1) Fix FTS5 parsing failures for slash-containing and quoted queries
- Hardened search query construction in `search_nodes` by introducing a dedicated FTS query builder.
- Terms are now safely quoted and embedded quotes are escaped before `MATCH` execution.
- Blank/whitespace-only input now returns an empty result set instead of passing invalid FTS syntax.

This prevents failures like:
- `fts5: syntax error near "/"`
- parser errors from malformed terms

### 2) Fix intermittent `Unknown tool` for MCP-prefixed tool names
- Updated tool dispatch in `ToolRegistry::execute` to normalize common MCP-prefixed aliases before lookup.
- Supports:
  - `mcp_coraline_coraline_*`
  - `mcp_coraline_*`
  - `mcp_*`

This makes calls such as `mcp_coraline_coraline_list_dir` resolve consistently to registered tool names.

## Tests
Added targeted unit tests for both fixes:
- alias-dispatch coverage in tool registry tests
- FTS query builder coverage for slash terms, embedded quotes, and blank input

Also verified with:
- `cargo test --all-features` (pass)

## Notes
The existing `tree-sitter-blazor` `ar: illegal option -- D` warnings still appear in this environment but did not affect test outcomes.

Closes #31