### PR TITLE
feat(audit): add markdown documentation audit tool for CLI + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ See the published CLI reference: <https://greysquirr3l.github.io/coraline/cli-re
 
 ## MCP Tools
 
-When running as an MCP server, Coraline exposes **26 tools** prefixed with `coraline_` (`coraline_semantic_search` requires the embedding model to be downloaded — see [Semantic Search](#semantic-search--llm-embeddings)).
+When running as an MCP server, Coraline exposes **27 tools** prefixed with `coraline_` (`coraline_semantic_search` requires the embedding model to be downloaded — see [Semantic Search](#semantic-search--llm-embeddings)).
 See the published MCP tools reference: <https://greysquirr3l.github.io/coraline/mcp-tools.html>.
 
 `coraline_semantic_search` also performs periodic freshness maintenance: it checks index staleness on an interval, auto-runs incremental sync when needed, and refreshes stale embeddings before returning results.
@@ -267,6 +267,12 @@ See the published MCP tools reference: <https://greysquirr3l.github.io/coraline/
 | Tool | Description |
 | ------ | ------------- |
 | `coraline_context` | Build structured context for an AI task |
+
+### Audit Tool
+
+| Tool | Description |
+| ------ | ------------- |
+| `coraline_audit_docs` | Audit Markdown docs for stale references and undocumented exports |
 
 ### File & Config Tools
 

--- a/crates/coraline/src/audit.rs
+++ b/crates/coraline/src/audit.rs
@@ -1,0 +1,109 @@
+#![forbid(unsafe_code)]
+
+//! Documentation accuracy auditing.
+//!
+//! After indexing + resolution, this module queries the knowledge graph for
+//! two categories of problems:
+//!
+//! 1. **Stale references** — inline `` `code_span` `` mentions in Markdown
+//!    files that could not be resolved to any symbol in the code graph.
+//!    These indicate docs that reference renamed, deleted, or moved symbols.
+//!
+//! 2. **Undocumented public API** — exported functions, types, structs, etc.
+//!    that have no inbound `references` edge from any Markdown node.
+
+use std::path::Path;
+
+use crate::db;
+
+// ─── Report types ─────────────────────────────────────────────────────────────
+
+/// A backtick reference in a doc file that could not be resolved to a code
+/// symbol — the symbol may have been renamed, moved, or deleted.
+#[derive(Debug, Clone)]
+pub struct StaleDocRef {
+    /// The name written inside the backticks, e.g. `"my_function"`.
+    pub reference_name: String,
+    /// Relative path of the Markdown file, e.g. `"docs/book/src/api.md"`.
+    pub doc_file: String,
+    /// The heading section containing the reference, or the file name if the
+    /// reference appears before any heading.
+    pub doc_section: String,
+    /// 1-based line number inside the Markdown file.
+    pub line: i64,
+    /// 0-based column.
+    pub column: i64,
+}
+
+/// An exported code symbol that is not mentioned in any documentation.
+#[derive(Debug, Clone)]
+pub struct UndocumentedExport {
+    /// The symbol's short name, e.g. `"MyStruct"`.
+    pub name: String,
+    /// Fully-qualified name including file path, e.g. `"src/lib.rs::MyStruct"`.
+    pub qualified_name: String,
+    /// Node kind as a lowercase string, e.g. `"function"`, `"struct"`.
+    pub kind: String,
+    /// Relative source file path.
+    pub file_path: String,
+    /// 1-based line number of the symbol definition.
+    pub start_line: i64,
+}
+
+/// The full output of a documentation audit run.
+#[derive(Debug, Default)]
+pub struct DocAuditReport {
+    /// References in docs that no longer point to a known symbol.
+    pub stale_refs: Vec<StaleDocRef>,
+    /// Exported symbols with no documentation coverage.
+    pub undocumented_exports: Vec<UndocumentedExport>,
+    /// Number of distinct Markdown files that have been indexed with headings.
+    pub doc_files_indexed: usize,
+    /// Total number of heading sections across all indexed Markdown files.
+    pub doc_sections_indexed: usize,
+}
+
+// ─── Core audit logic ─────────────────────────────────────────────────────────
+
+/// Run a documentation audit against the indexed knowledge graph at
+/// `project_root` and return the findings.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the database cannot be opened or queried.
+pub fn audit_docs(project_root: &Path) -> std::io::Result<DocAuditReport> {
+    let conn = db::open_database(project_root)?;
+
+    let raw_stale = db::list_doc_unresolved_refs(&conn)?;
+    let raw_undoc = db::list_undocumented_exports(&conn)?;
+    let (doc_files_indexed, doc_sections_indexed) = db::get_doc_coverage_stats(&conn)?;
+
+    let stale_refs = raw_stale
+        .into_iter()
+        .map(|r| StaleDocRef {
+            reference_name: r.reference_name,
+            doc_file: r.doc_file_path,
+            doc_section: r.doc_section_name,
+            line: r.line,
+            column: r.column,
+        })
+        .collect();
+
+    let undocumented_exports = raw_undoc
+        .into_iter()
+        .map(|n| UndocumentedExport {
+            name: n.name,
+            qualified_name: n.qualified_name,
+            kind: format!("{:?}", n.kind).to_ascii_lowercase(),
+            file_path: n.file_path,
+            start_line: n.start_line,
+        })
+        .collect();
+
+    Ok(DocAuditReport {
+        stale_refs,
+        undocumented_exports,
+        doc_files_indexed,
+        doc_sections_indexed,
+    })
+}

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -2,6 +2,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use coraline::audit;
 use coraline::config;
 use coraline::context;
 use coraline::db;
@@ -47,6 +48,8 @@ enum Command {
     Serve(ServeArgs),
     /// Check for available updates on crates.io.
     Update,
+    /// Audit documentation accuracy and coverage against the code graph.
+    AuditDocs(AuditDocsArgs),
     #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
     Embed(EmbedArgs),
     #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
@@ -245,6 +248,24 @@ enum ModelAction {
     Status,
 }
 
+#[derive(Debug, Args)]
+struct AuditDocsArgs {
+    #[arg(short = 'p', long = "path")]
+    path: Option<PathBuf>,
+    /// Hide stale-reference findings.
+    #[arg(long = "no-stale")]
+    no_stale: bool,
+    /// Hide undocumented-export findings.
+    #[arg(long = "no-undocumented")]
+    no_undocumented: bool,
+    /// Maximum items to display per category.
+    #[arg(short = 'l', long = "limit", default_value_t = 50)]
+    limit: usize,
+    /// Output raw JSON instead of formatted text.
+    #[arg(short = 'j', long = "json")]
+    json: bool,
+}
+
 fn main() {
     let cli = Cli::parse();
     if matches!(cli.command, None | Some(Command::Install)) {
@@ -271,6 +292,7 @@ fn main() {
         Command::Config(a) => a.path.clone(),
         Command::Hooks(a) => a.path.clone(),
         Command::Serve(a) => a.path.clone(),
+        Command::AuditDocs(a) => a.path.clone(),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Embed(a) => a.path.clone(),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
@@ -320,6 +342,7 @@ fn main() {
             }
         }
         Command::Update => run_update(),
+        Command::AuditDocs(args) => run_audit_docs(args),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Embed(args) => run_embed(&args),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
@@ -811,6 +834,109 @@ fn run_update() {
             eprintln!();
             eprintln!("You can manually check: https://crates.io/crates/coraline");
             std::process::exit(1);
+        }
+    }
+}
+
+fn run_audit_docs(args: AuditDocsArgs) {
+    let project_root = resolve_project_root(args.path);
+
+    let report = match audit::audit_docs(&project_root) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to run doc audit: {e}");
+            eprintln!("Make sure the project has been indexed (`coraline index`).");
+            std::process::exit(1);
+        }
+    };
+
+    if args.json {
+        let stale: Vec<_> = report
+            .stale_refs
+            .iter()
+            .take(args.limit)
+            .map(|r| {
+                serde_json::json!({
+                    "reference": r.reference_name,
+                    "doc_file": r.doc_file,
+                    "section": r.doc_section,
+                    "line": r.line,
+                    "column": r.column
+                })
+            })
+            .collect();
+        let undoc: Vec<_> = report
+            .undocumented_exports
+            .iter()
+            .take(args.limit)
+            .map(|u| {
+                serde_json::json!({
+                    "name": u.name,
+                    "qualified_name": u.qualified_name,
+                    "kind": u.kind,
+                    "file": u.file_path,
+                    "line": u.start_line
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "doc_files_indexed": report.doc_files_indexed,
+            "doc_sections_indexed": report.doc_sections_indexed,
+            "stale_refs": stale,
+            "undocumented_exports": undoc
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
+        return;
+    }
+
+    // Human-readable output
+    println!(
+        "Doc audit — {} file(s), {} section(s) indexed\n",
+        report.doc_files_indexed, report.doc_sections_indexed
+    );
+
+    if !args.no_stale {
+        let total = report.stale_refs.len();
+        if total == 0 {
+            println!("✓ No stale references found.");
+        } else {
+            println!(
+                "Stale references ({total} total{})\n",
+                if total > args.limit {
+                    format!(", showing first {}", args.limit)
+                } else {
+                    String::new()
+                }
+            );
+            for r in report.stale_refs.iter().take(args.limit) {
+                println!(
+                    "  {}:{} — `{}` (section: {})",
+                    r.doc_file, r.line, r.reference_name, r.doc_section
+                );
+            }
+            println!();
+        }
+    }
+
+    if !args.no_undocumented {
+        let total = report.undocumented_exports.len();
+        if total == 0 {
+            println!("✓ All exported symbols have documentation coverage.");
+        } else {
+            println!(
+                "Undocumented exports ({total} total{})\n",
+                if total > args.limit {
+                    format!(", showing first {}", args.limit)
+                } else {
+                    String::new()
+                }
+            );
+            for u in report.undocumented_exports.iter().take(args.limit) {
+                println!(
+                    "  {} {} — {} line {}",
+                    u.kind, u.name, u.file_path, u.start_line
+                );
+            }
         }
     }
 }

--- a/crates/coraline/src/db.rs
+++ b/crates/coraline/src/db.rs
@@ -958,6 +958,123 @@ pub fn is_valid_call_edge(
     Ok(false)
 }
 
+// ─── Doc-audit helpers ────────────────────────────────────────────────────────
+
+/// A single unresolved reference whose source node lives in a Markdown file.
+///
+/// After the resolution pass runs, these are references from doc sections to
+/// code symbols that could not be matched — i.e. stale documentation.
+#[derive(Debug, Clone)]
+pub struct DocUnresolvedRef {
+    /// The symbol name written in backticks in the doc (e.g. `"MyStruct"`).
+    pub reference_name: String,
+    /// Relative path of the Markdown file that contains the reference.
+    pub doc_file_path: String,
+    /// Name of the heading section the reference was found in, or the file
+    /// name when the reference appears before any heading.
+    pub doc_section_name: String,
+    /// 1-based line number inside the Markdown file.
+    pub line: i64,
+    /// 0-based column.
+    pub column: i64,
+}
+
+/// Return all unresolved references whose source node is in a Markdown file.
+///
+/// These represent inline `` `code_span` `` references that were not matched
+/// to any code symbol during the resolution pass — stale documentation.
+pub fn list_doc_unresolved_refs(conn: &Connection) -> std::io::Result<Vec<DocUnresolvedRef>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT ur.reference_name, n.file_path, n.name, ur.line, ur.col
+             FROM unresolved_refs ur
+             JOIN nodes n ON ur.from_node_id = n.id
+             WHERE n.language = 'markdown'
+             ORDER BY n.file_path, ur.line",
+        )
+        .map_err(io_other)?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(DocUnresolvedRef {
+                reference_name: row.get(0)?,
+                doc_file_path: row.get(1)?,
+                doc_section_name: row.get(2)?,
+                line: row.get(3)?,
+                column: row.get(4)?,
+            })
+        })
+        .map_err(io_other)?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row.map_err(io_other)?);
+    }
+    Ok(results)
+}
+
+/// Return exported code symbols that have **no** `references` edge arriving
+/// from any Markdown-language node.
+///
+/// These are public API items that are not mentioned anywhere in the
+/// documentation.
+pub fn list_undocumented_exports(conn: &Connection) -> std::io::Result<Vec<Node>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT n.id, n.kind, n.name, n.qualified_name, n.file_path, n.language,
+                    n.start_line, n.end_line, n.start_column, n.end_column,
+                    n.docstring, n.signature, n.visibility,
+                    n.is_exported, n.is_async, n.is_static, n.is_abstract,
+                    n.decorators, n.type_parameters, n.updated_at
+             FROM nodes n
+             WHERE n.is_exported = 1
+               AND n.language != 'markdown'
+               AND n.kind IN (
+                     'function','method','struct','class','interface',
+                     'trait','enum','type_alias','constant'
+                   )
+               AND NOT EXISTS (
+                     SELECT 1
+                     FROM edges e
+                     JOIN nodes src ON e.source = src.id
+                     WHERE e.target = n.id
+                       AND e.kind = 'references'
+                       AND src.language = 'markdown'
+                   )
+             ORDER BY n.file_path, n.start_line",
+        )
+        .map_err(io_other)?;
+
+    let rows = stmt.query_map([], row_to_node).map_err(io_other)?;
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row.map_err(io_other)?);
+    }
+    Ok(results)
+}
+
+/// Return `(doc_files_count, doc_sections_count)` — the number of distinct
+/// Markdown files that have been indexed with heading nodes, and the total
+/// number of heading sections across all of them.
+pub fn get_doc_coverage_stats(conn: &Connection) -> std::io::Result<(usize, usize)> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT COUNT(DISTINCT file_path), COUNT(id)
+             FROM nodes
+             WHERE language = 'markdown' AND kind = 'module'",
+        )
+        .map_err(io_other)?;
+
+    let (files, sections): (i64, i64) = stmt
+        .query_row([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .map_err(io_other)?;
+
+    Ok((
+        usize::try_from(files).unwrap_or(0),
+        usize::try_from(sections).unwrap_or(0),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::build_fts_query;

--- a/crates/coraline/src/extraction.rs
+++ b/crates/coraline/src/extraction.rs
@@ -625,6 +625,12 @@ fn extract_nodes(
         None => return (Vec::new(), Vec::new(), Vec::new()),
     };
 
+    // Markdown files use a specialised doc-structure extractor rather than the
+    // generic code-symbol walker.
+    if language == Language::Markdown {
+        return extract_markdown_nodes(file_path, source, tree.root_node(), root_id, now_ms);
+    }
+
     let mut nodes = Vec::new();
     let mut edges = Vec::new();
     let mut symbol_index = SymbolIndex::default();
@@ -2605,4 +2611,275 @@ fn now_millis() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_millis() as i64)
+}
+
+// ─── Markdown doc-structure extraction ──────────────────────────────────────
+//
+// Produces:
+//  • NodeKind::Module  for every ATX / setext heading  (the doc section)
+//  • UnresolvedReference (EdgeKind::References) for every inline `code_span`
+//    that looks like a symbol name, so the resolution pass can link them to
+//    real code nodes and the audit pass can report the ones that never resolved.
+
+/// Top-level entry point called from `extract_nodes` when language == Markdown.
+fn extract_markdown_nodes(
+    file_path: &str,
+    source: &str,
+    root: TsNode,
+    root_id: &str,
+    now_ms: i64,
+) -> (Vec<Node>, Vec<Edge>, Vec<UnresolvedReference>) {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut unresolved = Vec::new();
+    // heading_stack: (level 1-6, section_node_id) – used to associate code
+    // spans with their nearest enclosing section heading.
+    let mut heading_stack: Vec<(u8, String)> = Vec::new();
+
+    walk_markdown_node(
+        root,
+        source,
+        file_path,
+        root_id,
+        &mut heading_stack,
+        &mut nodes,
+        &mut edges,
+        &mut unresolved,
+        now_ms,
+    );
+
+    (nodes, edges, unresolved)
+}
+
+/// Recursive AST walker for Markdown trees.
+///
+/// * Headings   → `NodeKind::Module` nodes linked to the file via Contains.
+/// * `code_span`  → `UnresolvedReference` (References) from the current section
+///   (or the file node when no heading has been seen yet).
+/// * Everything else is recursed into without producing nodes.
+fn walk_markdown_node(
+    node: TsNode,
+    source: &str,
+    file_path: &str,
+    file_node_id: &str,
+    heading_stack: &mut Vec<(u8, String)>,
+    nodes: &mut Vec<Node>,
+    edges: &mut Vec<Edge>,
+    unresolved: &mut Vec<UnresolvedReference>,
+    now_ms: i64,
+) {
+    match node.kind() {
+        "atx_heading" | "setext_heading" => {
+            let level = markdown_heading_level(&node);
+            if let Some(text) = markdown_heading_text(&node, source) {
+                let start = node.start_position();
+                let end = node.end_position();
+                let qualified = format!("{file_path}::{text}");
+                let id = node_id_for_symbol(
+                    file_path,
+                    "module",
+                    &qualified,
+                    start.row as i64 + 1,
+                    start.column as i64,
+                );
+                nodes.push(Node {
+                    id: id.clone(),
+                    kind: NodeKind::Module,
+                    name: text,
+                    qualified_name: qualified,
+                    file_path: file_path.to_string(),
+                    language: Language::Markdown,
+                    start_line: start.row as i64 + 1,
+                    end_line: end.row as i64 + 1,
+                    start_column: start.column as i64,
+                    end_column: end.column as i64,
+                    docstring: None,
+                    signature: Some(format!("h{level}")),
+                    visibility: None,
+                    is_exported: false,
+                    is_async: false,
+                    is_static: false,
+                    is_abstract: false,
+                    decorators: None,
+                    type_parameters: None,
+                    updated_at: now_ms,
+                });
+                edges.push(Edge {
+                    source: file_node_id.to_string(),
+                    target: id.clone(),
+                    kind: EdgeKind::Contains,
+                    metadata: None,
+                    line: Some(start.row as i64 + 1),
+                    column: Some(start.column as i64),
+                });
+                // Keep the stack tidy: pop any heading at the same or deeper level.
+                heading_stack.retain(|(l, _)| *l < level);
+                heading_stack.push((level, id));
+            }
+            // Do NOT recurse into heading children — heading text like
+            // `fn foo()` should not be treated as a symbol reference.
+        }
+        "code_span" => {
+            if let Some(raw) = markdown_code_span_text(&node, source) {
+                // Strip trailing `()` so `foo()` resolves the same as `foo`.
+                let name = raw.trim_end_matches("()").trim().to_string();
+                if looks_like_symbol(&name) {
+                    let start = node.start_position();
+                    let from_id = heading_stack
+                        .last()
+                        .map_or(file_node_id, |(_, id)| id.as_str());
+                    unresolved.push(UnresolvedReference {
+                        from_node_id: from_id.to_string(),
+                        reference_name: name,
+                        reference_kind: EdgeKind::References,
+                        line: start.row as i64 + 1,
+                        column: start.column as i64,
+                        candidates: None,
+                    });
+                }
+            }
+        }
+        _ => {
+            for child in node.children(&mut node.walk()) {
+                walk_markdown_node(
+                    child,
+                    source,
+                    file_path,
+                    file_node_id,
+                    heading_stack,
+                    nodes,
+                    edges,
+                    unresolved,
+                    now_ms,
+                );
+            }
+        }
+    }
+}
+
+/// Determine ATX / setext heading level (1–6).
+fn markdown_heading_level(node: &TsNode) -> u8 {
+    if node.kind() == "setext_heading" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "setext_h1_underline" => return 1,
+                "setext_h2_underline" => return 2,
+                _ => {}
+            }
+        }
+        return 1;
+    }
+    // atx_heading: inspect marker children.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "atx_h1_marker" => return 1,
+            "atx_h2_marker" => return 2,
+            "atx_h3_marker" => return 3,
+            "atx_h4_marker" => return 4,
+            "atx_h5_marker" => return 5,
+            "atx_h6_marker" => return 6,
+            _ => {}
+        }
+    }
+    1
+}
+
+/// Extract the plain-text content of a heading node.
+///
+/// Returns `None` if the heading has no discernible text.
+fn markdown_heading_text(node: &TsNode, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "heading_content" {
+            return child
+                .utf8_text(source.as_bytes())
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+        }
+    }
+    None
+}
+
+/// Extract the text content from a `code_span` node, stripping the surrounding
+/// backtick delimiters.
+fn markdown_code_span_text(node: &TsNode, source: &str) -> Option<String> {
+    // Prefer explicit `text` children (avoids including delimiter backticks).
+    let mut text = String::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "text" {
+            if let Ok(t) = child.utf8_text(source.as_bytes()) {
+                text.push_str(t);
+            }
+        }
+    }
+    if !text.is_empty() {
+        return Some(text);
+    }
+    // Fallback: take the full node text and strip surrounding backticks.
+    node.utf8_text(source.as_bytes())
+        .ok()
+        .map(|s| s.trim_matches('`').trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Heuristic: does `s` look like a code symbol worth tracking?
+///
+/// Rejects:
+/// * strings with whitespace (these are phrases, not identifiers)
+/// * single characters
+/// * pure numeric literals
+/// * common value literals that aren't project-specific symbols
+fn looks_like_symbol(s: &str) -> bool {
+    if s.len() < 2 || s.contains(' ') {
+        return false;
+    }
+    if s.chars()
+        .all(|c| c.is_ascii_digit() || c == '.' || c == '_')
+    {
+        return false;
+    }
+    let first = s.chars().next().unwrap_or('\0');
+    if !first.is_alphabetic() && first != '_' {
+        return false;
+    }
+    !matches!(
+        s,
+        "true"
+            | "false"
+            | "null"
+            | "nil"
+            | "None"
+            | "Some"
+            | "Ok"
+            | "Err"
+            | "self"
+            | "super"
+            | "crate"
+            | "pub"
+            | "fn"
+            | "let"
+            | "mut"
+            | "use"
+            | "mod"
+            | "struct"
+            | "enum"
+            | "impl"
+            | "trait"
+            | "type"
+            | "async"
+            | "await"
+            | "return"
+            | "if"
+            | "else"
+            | "match"
+            | "for"
+            | "while"
+            | "loop"
+            | "break"
+            | "continue"
+    )
 }

--- a/crates/coraline/src/lib.rs
+++ b/crates/coraline/src/lib.rs
@@ -2,6 +2,7 @@
 // Transitive dependency version conflicts we can't control (base64, getrandom, hashbrown).
 #![allow(clippy::multiple_crate_versions)]
 
+pub mod audit;
 pub mod config;
 pub mod context;
 pub mod db;

--- a/crates/coraline/src/tools/audit_tools.rs
+++ b/crates/coraline/src/tools/audit_tools.rs
@@ -1,0 +1,135 @@
+#![forbid(unsafe_code)]
+
+//! MCP tool for doc-accuracy auditing.
+
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+
+use crate::audit;
+
+use super::{Tool, ToolError, ToolResult};
+
+/// MCP tool that audits documentation coverage and accuracy against the
+/// indexed code graph.
+///
+/// Returns:
+/// * **`stale_refs`** — inline backtick references in Markdown files that could
+///   not be resolved to any code symbol (renamed / deleted / moved).
+/// * **`undocumented_exports`** — exported functions, types, etc. with no
+///   inbound `references` edge from any Markdown node.
+pub struct AuditDocsTool {
+    project_root: PathBuf,
+}
+
+impl AuditDocsTool {
+    pub const fn new(project_root: PathBuf) -> Self {
+        Self { project_root }
+    }
+}
+
+impl Tool for AuditDocsTool {
+    fn name(&self) -> &'static str {
+        "coraline_audit_docs"
+    }
+
+    fn description(&self) -> &'static str {
+        "Audit documentation accuracy and coverage against the indexed code graph. \
+         Returns two lists: (1) stale_refs — inline `code_span` references in \
+         Markdown files that do not resolve to any known symbol, indicating \
+         renamed/deleted/moved items; (2) undocumented_exports — exported public \
+         symbols with no documentation reference. Requires that Markdown doc files \
+         are included in the index path."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "show_undocumented": {
+                    "type": "boolean",
+                    "description": "Include undocumented public exports in the output (default: true).",
+                    "default": true
+                },
+                "show_stale": {
+                    "type": "boolean",
+                    "description": "Include stale doc references in the output (default: true).",
+                    "default": true
+                },
+                "limit": {
+                    "type": "number",
+                    "description": "Maximum number of items to return per category (default: 50).",
+                    "default": 50
+                }
+            },
+            "required": []
+        })
+    }
+
+    fn execute(&self, params: Value) -> ToolResult {
+        let show_undocumented = params
+            .get("show_undocumented")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let show_stale = params
+            .get("show_stale")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map_or(50, |n| usize::try_from(n).unwrap_or(50));
+
+        let report = audit::audit_docs(&self.project_root)
+            .map_err(|e| ToolError::internal_error(e.to_string()))?;
+
+        let stale = if show_stale {
+            report
+                .stale_refs
+                .iter()
+                .take(limit)
+                .map(|r| {
+                    json!({
+                        "reference": r.reference_name,
+                        "doc_file": r.doc_file,
+                        "section": r.doc_section,
+                        "line": r.line,
+                        "column": r.column
+                    })
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
+        let undoc = if show_undocumented {
+            report
+                .undocumented_exports
+                .iter()
+                .take(limit)
+                .map(|u| {
+                    json!({
+                        "name": u.name,
+                        "qualified_name": u.qualified_name,
+                        "kind": u.kind,
+                        "file": u.file_path,
+                        "line": u.start_line
+                    })
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
+        Ok(json!({
+            "summary": {
+                "doc_files_indexed": report.doc_files_indexed,
+                "doc_sections_indexed": report.doc_sections_indexed,
+                "stale_refs_count": report.stale_refs.len(),
+                "undocumented_exports_count": report.undocumented_exports.len()
+            },
+            "stale_refs": stale,
+            "undocumented_exports": undoc
+        }))
+    }
+}

--- a/crates/coraline/src/tools/mod.rs
+++ b/crates/coraline/src/tools/mod.rs
@@ -9,6 +9,7 @@
 use serde_json::Value;
 use std::collections::HashMap;
 
+pub mod audit_tools;
 pub mod context_tools;
 pub mod file_tools;
 pub mod graph_tools;
@@ -208,6 +209,11 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
 
     // Register context tools
     registry.register(Box::new(context_tools::BuildContextTool::new(
+        project_root.to_path_buf(),
+    )));
+
+    // Register audit tools
+    registry.register(Box::new(audit_tools::AuditDocsTool::new(
         project_root.to_path_buf(),
     )));
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # Coraline MCP Tools Reference
 
-Coraline exposes **27 MCP tools** when running as an MCP server (`coraline serve --mcp`).
+Coraline exposes **28 MCP tools** when running as an MCP server (`coraline serve --mcp`).
 All tool names are prefixed with `coraline_` to avoid collisions with other MCP servers.
 
 Protocol notes:
@@ -8,7 +8,7 @@ Protocol notes:
 - Expects `notifications/initialized` after `initialize` before normal requests
 - `tools/list` supports pagination via `cursor` and `nextCursor`
 
-`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. The remaining 26 tools are typically available; memory-backed tools may be skipped if their initialization fails (e.g. due to filesystem or permission issues).
+`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. The remaining 27 tools are typically available; memory-backed tools may be skipped if their initialization fails (e.g. due to filesystem or permission issues).
 
 ### Background Auto-Sync
 
@@ -38,6 +38,7 @@ When the MCP server starts, it spawns a background thread that periodically chec
 | | `coraline_find_references` | Find all references to a symbol |
 | | `coraline_node` | Get full node details and source code |
 | **Context** | `coraline_context` | Build structured context for an AI task |
+| **Audit** | `coraline_audit_docs` | Audit Markdown docs for stale references and undocumented exports |
 | **File** | `coraline_read_file` | Read file contents |
 | | `coraline_list_dir` | List directory contents |
 | | `coraline_find_file` | Find files by glob pattern |
@@ -382,6 +383,56 @@ Build structured context for an AI task description. Searches the graph, travers
 | `format` | string | | `"markdown"` | `"markdown"` or `"json"` |
 
 **Output:** A Markdown or JSON document containing relevant symbols and code, ready to paste as context for an LLM.
+
+---
+
+## Audit Tool
+
+### `coraline_audit_docs`
+
+Audit Markdown documentation coverage against the indexed code graph.
+
+Detects two classes of issues:
+- `stale_refs`: inline code-span symbol references in Markdown that do not resolve to indexed symbols
+- `undocumented_exports`: exported code symbols with no inbound `references` edge from Markdown docs
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `show_undocumented` | boolean | | `true` | Include undocumented export results |
+| `show_stale` | boolean | | `true` | Include stale reference results |
+| `limit` | number | | `50` | Max items returned per result set |
+
+**Output:**
+```json
+{
+  "summary": {
+    "doc_files_indexed": 12,
+    "doc_sections_indexed": 89,
+    "stale_ref_count": 3,
+    "undocumented_export_count": 7
+  },
+  "stale_refs": [
+    {
+      "reference": "resolve_unresolved",
+      "doc_file": "docs/ARCHITECTURE.md",
+      "section": "Resolution",
+      "line": 42,
+      "column": 18
+    }
+  ],
+  "undocumented_exports": [
+    {
+      "name": "audit_docs",
+      "qualified_name": "coraline::audit::audit_docs",
+      "kind": "function",
+      "file": "crates/coraline/src/audit.rs",
+      "line": 48
+    }
+  ]
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- add Markdown extraction support for documentation-aware indexing
  - headings are indexed as module-like section nodes
  - code spans are captured as unresolved references for resolution
- add documentation audit domain module and DB queries
  - stale Markdown references detection
  - undocumented exported symbol detection
  - doc coverage stats
- add new MCP tool: `coraline_audit_docs`
- add new CLI command: `coraline audit-docs`
- wire tool registration and public module exports
- update documentation
  - MCP tools reference now includes `coraline_audit_docs`
  - README MCP tools section updated with audit tool and counts

## Why
This adds first-class documentation accuracy checks to Coraline so docs can be audited against the indexed code graph, including stale symbol references and missing documentation coverage.

## Validation
- `cargo build --all-features`
- `cargo lint`