### PR TITLE
ci(security): run cargo-audit and cargo-deny on every PR

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,11 +8,13 @@ on:
       - "**/Cargo.lock"
       - "deny.toml"
       - ".github/workflows/security.yml"
+  # NOTE: pull_request intentionally has NO paths filter — the branch
+  # protection on `main` requires the `Check licenses and bans` check to be
+  # reported on every PR, and adding path filters here would prevent the
+  # check from running on PRs that only touch workflow files (e.g.
+  # dependabot GitHub Actions bumps). The push trigger still has path
+  # filters so main-branch pushes don't always run this workflow.
   pull_request:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - ".github/workflows/security.yml"
   schedule:
     - cron: "0 0 * * *" # Daily at midnight UTC
   workflow_dispatch:


### PR DESCRIPTION
The branch protection on `main` requires the `Check licenses and bans` check to be reported on every PR, but the `security.yml` workflow had a `paths` filter on `pull_request` that only triggered on `**/Cargo.toml`, `**/Cargo.lock`, and `.github/workflows/security.yml`. That filter prevented the check from running on dependabot PRs that only touched `.github/workflows/*.yml` files (PRs #65, #66, #67, #68 — the `github/codeql-action/*` and `actions/attest-build-provenance` version bumps), causing them to be stuck `BLOCKED` despite passing all other required checks.

Removing the paths filter on `pull_request` ensures the `Check licenses and bans` check is reported on every PR. The `push` trigger keeps its path filters so main-branch pushes don't always run this workflow unnecessarily.