### PR TITLE
ci: align codeql-action init/autobuild/analyze on v4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,13 +26,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.30.12
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.30.12
         with:
           languages: javascript # For tree-sitter grammar.js
           # CodeQL doesn't directly support Rust, but we include it for any embedded scripts
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.30.12
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.30.12
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.30.12

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,15 +26,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.30.12
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript # For tree-sitter grammar.js
           # CodeQL doesn't directly support Rust, but we include it for any embedded scripts
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.30.12
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.30.12
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:javascript"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.30.12
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.30.12
         with:
           languages: javascript # For tree-sitter grammar.js
           # CodeQL doesn't directly support Rust, but we include it for any embedded scripts


### PR DESCRIPTION
Originally recreated the closed dependabot PR #64 (bump `codeql-action/init` 4.36.2 → 4.36.3), matching the `autobuild`/`analyze` bumps merged in #66/#68.

That wasn't sufficient on its own: `analyze` had already been bumped further to v4.37.3 in #66 (a different target version than `autobuild`'s #68), so pinning `init` to v4.36.3 just moved the version mismatch instead of fixing it. CodeQL hard-fails with `Loaded a configuration file for version X, but running version Y` whenever `init`/`autobuild`/`analyze` don't all resolve to the exact same `codeql-action` commit — confirmed via this PR's own failing `Analyze` check.

Now bumps `init` **and** `autobuild` to `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (v4.37.3) — the same commit already used by `analyze` — so all three steps are in lockstep.