### PR TITLE
fix(mcp): don't create .coraline/ before a project is actually initialized

### DIFF
--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -280,14 +280,15 @@ fn main() {
         Command::Install => None,
     };
     let project_root = resolve_project_root(project_root_hint);
-    // Don't create .coraline/logs/ before the init command runs — that would
-    // cause is_initialized() to return true and block a fresh init.
-    let log_root =
-        if matches!(command, Command::Init(_)) && !project_root.join(".coraline").is_dir() {
-            None
-        } else {
-            Some(project_root.as_path())
-        };
+    // Suppress logging entirely during a fresh `init` so stdout progress
+    // output stays clean. (logging::init independently refuses to create
+    // .coraline/logs/ for any command until the project is actually
+    // initialized, so this is a UX nicety, not the correctness guard.)
+    let log_root = if matches!(command, Command::Init(_)) && !is_initialized(&project_root) {
+        None
+    } else {
+        Some(project_root.as_path())
+    };
     let _log_guard = logging::init(log_root);
     info!("coraline starting");
     debug!(command = ?command, "dispatching command");
@@ -1356,8 +1357,11 @@ fn resolve_project_root(path: Option<PathBuf>) -> PathBuf {
 }
 
 fn is_initialized(project_root: &Path) -> bool {
-    let dir = project_root.join(".coraline");
-    dir.is_dir()
+    // `.coraline/` alone isn't a reliable signal — other code (e.g. the
+    // logger) can create it before `coraline init` has actually run.
+    // `config.toml` is only ever written by a real init, so it's the
+    // authoritative marker.
+    config::toml_config_path(project_root).is_file()
 }
 
 fn create_coraline_dir(project_root: &Path) -> std::io::Result<()> {
@@ -1506,5 +1510,37 @@ fn is_executable(path: &PathBuf) -> bool {
     #[cfg(not(unix))]
     {
         path.exists() && path.is_file()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    /// A bare `.coraline/` directory (e.g. left behind by logging, or any
+    /// other incidental creator) must not count as "initialized" — only a
+    /// real `coraline init` writes `config.toml`.
+    #[test]
+    fn is_initialized_false_for_bare_coraline_dir() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path();
+        std::fs::create_dir_all(root.join(".coraline").join("logs"))?;
+
+        assert!(!is_initialized(root));
+        Ok(())
+    }
+
+    #[test]
+    fn is_initialized_true_once_config_toml_exists() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path();
+        let coraline_dir = root.join(".coraline");
+        std::fs::create_dir_all(&coraline_dir)?;
+        std::fs::write(coraline_dir.join("config.toml"), "")?;
+
+        assert!(is_initialized(root));
+        Ok(())
     }
 }

--- a/crates/coraline/src/logging.rs
+++ b/crates/coraline/src/logging.rs
@@ -3,8 +3,10 @@
 //! Structured logging setup for Coraline.
 //!
 //! Initializes `tracing` with:
-//! - File output to `.coraline/logs/coraline.log` (daily rotation)
-//! - Stderr fallback when no project root is available
+//! - File output to `.coraline/logs/coraline.log` (daily rotation), only
+//!   once the project has been initialized (`.coraline/config.toml` exists)
+//! - Stderr fallback when no project root is available, or the project
+//!   hasn't been initialized yet
 //! - Log level controlled by `CORALINE_LOG` env var (default: `coraline=info`)
 
 use std::path::Path;
@@ -28,8 +30,11 @@ pub struct LogGuard {
 /// Log level is read from `CORALINE_LOG` environment variable (e.g. `debug`,
 /// `coraline=trace`). Defaults to `coraline=info`.
 ///
-/// If `project_root` is provided and `.coraline/logs/` can be created, logs
-/// are written to a daily-rotating file there. Otherwise logs go to stderr.
+/// If `project_root` is provided, the project has already been initialized
+/// (`.coraline/config.toml` exists), and `.coraline/logs/` can be created,
+/// logs are written to a daily-rotating file there. Otherwise logs go to
+/// stderr — in particular, an uninitialized project never gets
+/// `.coraline/` created just from logging.
 pub fn init(project_root: Option<&Path>) -> LogGuard {
     let env_filter =
         EnvFilter::try_from_env("CORALINE_LOG").unwrap_or_else(|_| EnvFilter::new("coraline=info"));

--- a/crates/coraline/src/logging.rs
+++ b/crates/coraline/src/logging.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
+use crate::config;
+
 /// Opaque guard that must be kept alive for the duration of the program.
 /// When dropped, the file appender worker thread flushes and exits.
 pub struct LogGuard {
@@ -38,8 +40,14 @@ pub fn init(project_root: Option<&Path>) -> LogGuard {
         return LogGuard { _guard: None };
     }
 
-    // Attempt to set up file logging
-    if let Some(root) = project_root {
+    // Attempt to set up file logging, but only into an already-initialized
+    // project. Creating `.coraline/logs/` on a project that hasn't run
+    // `coraline init` yet would make directory-existence-based init checks
+    // see a partially-initialized project (logs only, no config/db) and
+    // block a real `coraline init` from running cleanly.
+    if let Some(root) = project_root
+        && config::toml_config_path(root).is_file()
+    {
         let log_dir = root.join(".coraline").join("logs");
         if std::fs::create_dir_all(&log_dir).is_ok() {
             let file_appender = tracing_appender::rolling::daily(&log_dir, "coraline.log");
@@ -65,4 +73,48 @@ pub fn init(project_root: Option<&Path>) -> LogGuard {
         .try_init();
 
     LogGuard { _guard: None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    /// Regression test for: the MCP server (and any other non-`init`
+    /// command) starting logging against an uninitialized project used to
+    /// create `.coraline/logs/` on its own, which made `is_initialized()`
+    /// checks see a partially-initialized project and forced users to
+    /// delete `.coraline/` by hand before `coraline init` would work.
+    #[test]
+    fn init_does_not_create_coraline_dir_for_uninitialized_project() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path();
+        assert!(!root.join(".coraline").exists());
+
+        let _guard = init(Some(root));
+
+        assert!(
+            !root.join(".coraline").exists(),
+            ".coraline/ must not be created for a project without config.toml"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn init_creates_log_dir_for_already_initialized_project() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path();
+        let coraline_dir = root.join(".coraline");
+        std::fs::create_dir_all(&coraline_dir)?;
+        std::fs::write(coraline_dir.join("config.toml"), "")?;
+
+        let _guard = init(Some(root));
+
+        assert!(
+            coraline_dir.join("logs").is_dir(),
+            "logs/ should be created once the project is genuinely initialized"
+        );
+        Ok(())
+    }
 }

--- a/crates/coraline/src/mcp.rs
+++ b/crates/coraline/src/mcp.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
+use crate::config;
 use crate::tools::{ToolRegistry, create_default_registry};
 
 const PROTOCOL_VERSION: &str = "2025-06-18";
@@ -344,11 +345,76 @@ fn strip_file_uri(uri: &str) -> String {
 }
 
 fn is_initialized(project_root: &Path) -> bool {
-    project_root.join(".coraline").is_dir()
+    // `.coraline/` alone isn't a reliable signal — other code (e.g. the
+    // logger) can create it before `coraline init` has actually run.
+    // `config.toml` is only ever written by a real init, so it's the
+    // authoritative marker.
+    config::toml_config_path(project_root).is_file()
 }
 
 fn send_response(response: Value) -> io::Result<()> {
     let mut stdout = io::stdout();
     writeln!(stdout, "{}", response)?;
     stdout.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    /// A bare `.coraline/` directory (e.g. left behind by logging, or any
+    /// other incidental creator) must not count as "initialized" — only a
+    /// real `coraline init` writes `config.toml`.
+    #[test]
+    fn is_initialized_false_for_bare_coraline_dir() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path();
+        std::fs::create_dir_all(root.join(".coraline").join("logs"))?;
+
+        assert!(!is_initialized(root));
+        Ok(())
+    }
+
+    #[test]
+    fn is_initialized_true_once_config_toml_exists() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path();
+        let coraline_dir = root.join(".coraline");
+        std::fs::create_dir_all(&coraline_dir)?;
+        std::fs::write(coraline_dir.join("config.toml"), "")?;
+
+        assert!(is_initialized(root));
+        Ok(())
+    }
+
+    /// End-to-end regression: constructing an `McpServer` for a fresh,
+    /// uninitialized project and driving an `initialize` request must
+    /// report the "not initialized" error without ever creating
+    /// `.coraline/` as a side effect.
+    #[test]
+    fn handle_initialize_on_fresh_project_does_not_create_coraline_dir() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path().to_path_buf();
+
+        let mut server = McpServer::new(Some(root.clone()));
+        let message = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        });
+        server.handle_message(message)?;
+
+        assert!(
+            server.init_error.is_some(),
+            "expected init_error to be set for an uninitialized project"
+        );
+        assert!(
+            !root.join(".coraline").exists(),
+            ".coraline/ must not be created just from handling an MCP initialize request"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- The MCP server (and any command other than a fresh `coraline init`) called `logging::init()` unconditionally on startup, which created `.coraline/logs/coraline.log` even against a project that had never run `coraline init`.
- That partial `.coraline/` directory satisfied the old `is_dir()`-only `is_initialized()` check, so a later `coraline init` treated the project as already initialized and refused to set it up without `--force` — requiring users to manually delete `.coraline/` before initializing.
- `logging::init()` now only writes to `.coraline/logs/` once `.coraline/config.toml` already exists; otherwise it falls back to stderr without touching the filesystem.
- Both `is_initialized()` copies (CLI and MCP) now check for `config.toml` specifically — the file only a real `coraline init` ever writes — instead of treating `.coraline/` directory existence as proof of initialization.

## Test plan
- [x] Added regression tests: `logging::tests::{init_does_not_create_coraline_dir_for_uninitialized_project, init_creates_log_dir_for_already_initialized_project}`, `mcp::tests::{is_initialized_false_for_bare_coraline_dir, is_initialized_true_once_config_toml_exists, handle_initialize_on_fresh_project_does_not_create_coraline_dir}`, `bin::coraline::tests::{is_initialized_false_for_bare_coraline_dir, is_initialized_true_once_config_toml_exists}`
- [x] `cargo test --all-features` — 63/63 passing
- [x] `cargo clippy` (full project baseline, zero `#[allow(...)]` suppressions) — clean
- [x] release build + docs + mdbook (via pre-push hook)