### PR TITLE
chore(gitignore): ignore local agent/session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ opencode.jsonc
 .gitignore
 RTK.md
 .claude/
+
+# Do Not Modify Below This Line
+AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,8 @@ CLAUDE.md
 docs/IMPROVEMENT_PLAN.md
 .cargo/config.toml
 .cargo/config.toml
+notes.txt
+opencode.jsonc
+.gitignore
+RTK.md
+.claude/


### PR DESCRIPTION
## Summary
- Ignores `notes.txt`, `opencode.jsonc`, `RTK.md`, and `.claude/` as local per-machine artifacts.
- Also ignores `AGENTS.md` (kept locally, not committed) under a `# Do Not Modify Below This Line` marker.

## Test plan
- [x] `cargo test --all-features` / clippy / release build / docs / mdbook (via pre-push hook)