### PR TITLE
Make “~/.config/coraline/“ a global config fallback for both, “./config.toml” and “./models/“

### DIFF
--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -245,6 +245,11 @@ enum ModelAction {
     },
     /// Show which model files are present in the model directory.
     Status,
+    /// Copy model files from the legacy per-project location to the shared global directory.
+    ///
+    /// The legacy location is `.coraline/models/nomic-embed-text-v1.5/` inside the
+    /// project root. After migration the old directory can be removed manually.
+    Migrate,
 }
 
 fn main() {
@@ -336,7 +341,10 @@ fn run_model(args: ModelArgs) {
     let model_dir = cfg
         .vectors
         .model_dir
-        .map_or_else(|| vectors::default_model_dir(&project_root), PathBuf::from);
+        .map_or_else(vectors::global_model_dir, PathBuf::from);
+
+    // Lazily migrate any model files found in the legacy per-project location.
+    vectors::maybe_migrate_legacy_model(&vectors::global_model_dir(), &project_root);
 
     match args.action {
         ModelAction::Download { variant, force } => {
@@ -371,6 +379,47 @@ fn run_model(args: ModelArgs) {
                     println!("  {name:<30}  (not present)");
                 }
             }
+        }
+        ModelAction::Migrate => {
+            let global_dir = vectors::global_model_dir();
+            let legacy_dir = project_root
+                .join(".coraline")
+                .join("models")
+                .join(vectors::DEFAULT_MODEL);
+
+            let global_has_model = vectors::MODEL_PREFERENCE_ORDER
+                .iter()
+                .any(|name| global_dir.join(name).exists());
+
+            if global_has_model {
+                println!(
+                    "Shared model directory already populated: {}",
+                    global_dir.display()
+                );
+                println!("Nothing to migrate.");
+
+                return;
+            }
+
+            let legacy_has_model = vectors::MODEL_PREFERENCE_ORDER
+                .iter()
+                .any(|name| legacy_dir.join(name).exists());
+
+            if !legacy_has_model {
+                println!(
+                    "No model files found in legacy location: {}",
+                    legacy_dir.display()
+                );
+                println!(
+                    "Run `coraline model download` to fetch the model into {}",
+                    global_dir.display()
+                );
+
+                return;
+            }
+
+            // The lazy migration function prints its own message when files are copied.
+            vectors::maybe_migrate_legacy_model(&global_dir, &project_root);
         }
     }
 }

--- a/crates/coraline/src/config.rs
+++ b/crates/coraline/src/config.rs
@@ -257,6 +257,31 @@ pub const fn is_language_supported(language: &Language) -> bool {
 /// Filename for the user-editable TOML configuration.
 pub const TOML_CONFIG_FILENAME: &str = "config.toml";
 
+/// XDG-compliant base directory for global Coraline configuration.
+///
+/// Returns `$XDG_CONFIG_HOME/coraline` when the env variable is set, otherwise
+/// `~/.config/coraline`. Falls back to `.config/coraline` (relative to CWD)
+/// when `HOME` is also absent.
+pub fn global_config_dir() -> PathBuf {
+    let config_base = std::env::var("XDG_CONFIG_HOME").map_or_else(
+        |_| {
+            std::env::var("HOME").map_or_else(
+                |_| PathBuf::from(".config"),
+                |h| PathBuf::from(h).join(".config"),
+            )
+        },
+        PathBuf::from,
+    );
+
+    config_base.join("coraline")
+}
+
+/// Path to the global config file: `~/.config/coraline/config.toml`.
+pub fn global_toml_config_path() -> PathBuf {
+    global_config_dir().join(TOML_CONFIG_FILENAME)
+}
+
+/// Path to the per-project config file: `<project_root>/.coraline/config.toml`.
 pub fn toml_config_path(project_root: &Path) -> PathBuf {
     project_root.join(".coraline").join(TOML_CONFIG_FILENAME)
 }
@@ -325,7 +350,7 @@ pub struct VectorsConfig {
     /// Batch size for embedding generation.
     pub batch_size: usize,
     /// Path to the model directory (containing an ONNX file + tokenizer.json).
-    /// Defaults to `.coraline/models/nomic-embed-text-v1.5/`.
+    /// Defaults to `~/.config/coraline/models/nomic-embed-text-v1.5/`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_dir: Option<String>,
     /// Specific ONNX filename to use (e.g. `model_int8.onnx`).
@@ -473,15 +498,70 @@ impl CoralineConfig {
     }
 }
 
-/// Load the TOML config from `.coraline/config.toml`, returning defaults if
-/// the file does not exist.  Returns an error only on parse failures.
+/// Load and merge config from `~/.config/coraline/config.toml` (global) and
+/// `<project_root>/.coraline/config.toml` (local).
+///
+/// Local values take precedence at the individual field level: a local
+/// `[vectors]` section that only sets `enabled = true` still inherits
+/// `model_dir` from the global config. Returns struct defaults when neither
+/// file exists.
 pub fn load_toml_config(project_root: &Path) -> std::io::Result<CoralineConfig> {
+    let global = load_raw_toml_value(&global_toml_config_path());
+    let local = load_raw_toml_value(&toml_config_path(project_root));
+
+    let merged = match (global, local) {
+        (Some(g), Some(l)) => merge_toml_values(g, l),
+        (Some(g), None) => g,
+        (None, Some(l)) => l,
+        (None, None) => return Ok(CoralineConfig::default_config()),
+    };
+
+    CoralineConfig::deserialize(merged)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Load only the per-project config without applying the global fallback.
+///
+/// Use this when you need to read and write back a single config value without
+/// unintentionally baking global defaults into the local file.
+pub fn load_local_toml_config(project_root: &Path) -> std::io::Result<CoralineConfig> {
     let path = toml_config_path(project_root);
     if !path.exists() {
         return Ok(CoralineConfig::default_config());
     }
     let raw = fs::read_to_string(&path)?;
     toml::from_str(&raw).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Read a TOML file into a raw `toml::Value`, returning `None` if the file
+/// does not exist or fails to parse.
+fn load_raw_toml_value(path: &Path) -> Option<toml::Value> {
+    if !path.exists() {
+        return None;
+    }
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| toml::from_str(&raw).ok())
+}
+
+/// Deep-merge two TOML values with `overlay` winning at every leaf.
+///
+/// When both values are tables the merge recurses into each key. For any other
+/// combination the overlay value replaces the base value entirely.
+fn merge_toml_values(base: toml::Value, overlay: toml::Value) -> toml::Value {
+    match (base, overlay) {
+        (toml::Value::Table(mut base_tbl), toml::Value::Table(overlay_tbl)) => {
+            for (key, overlay_val) in overlay_tbl {
+                let merged = match base_tbl.remove(&key) {
+                    Some(base_val) => merge_toml_values(base_val, overlay_val),
+                    None => overlay_val,
+                };
+                base_tbl.insert(key, merged);
+            }
+            toml::Value::Table(base_tbl)
+        }
+        (_, overlay) => overlay,
+    }
 }
 
 /// Persist the TOML config to `.coraline/config.toml`.
@@ -681,7 +761,7 @@ model      = "nomic-embed-text-v1.5"
 dimension  = 768
 batch_size = 32
 max_seq_len = 512
-# model_dir  = ".coraline/models/nomic-embed-text-v1.5"  # override default path
+# model_dir  = "~/.config/coraline/models/nomic-embed-text-v1.5"  # override default path
 # model_file = "model_int8.onnx"                          # pin a specific variant
 
 [security]

--- a/crates/coraline/src/tools/file_tools.rs
+++ b/crates/coraline/src/tools/file_tools.rs
@@ -640,8 +640,9 @@ impl Tool for UpdateConfigTool {
             .ok_or_else(|| ToolError::invalid_params("value is required"))?
             .clone();
 
-        // Load current config, mutate it as JSON, write back
-        let cfg = crate::config::load_toml_config(&self.project_root)
+        // Load only the local config so we patch and save just project-level
+        // values without baking global defaults into the per-project file.
+        let cfg = crate::config::load_local_toml_config(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to load config: {e}")))?;
 
         let mut cfg_json = serde_json::to_value(&cfg)

--- a/crates/coraline/src/tools/mod.rs
+++ b/crates/coraline/src/tools/mod.rs
@@ -521,7 +521,12 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
 
     // Register semantic search only when at least one ONNX model variant is present.
     #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-    let model_dir = crate::vectors::default_model_dir(project_root);
+    let model_dir = {
+        let cfg = crate::config::load_toml_config(project_root).unwrap_or_default();
+        cfg.vectors
+            .model_dir
+            .map_or_else(crate::vectors::global_model_dir, std::path::PathBuf::from)
+    };
     #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
     if crate::vectors::MODEL_PREFERENCE_ORDER
         .iter()

--- a/crates/coraline/src/vectors.rs
+++ b/crates/coraline/src/vectors.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Quick start
 //!
-//! 1. Download a model into `.coraline/models/nomic-embed-text-v1.5/`.
+//! 1. Download a model into `~/.config/coraline/models/nomic-embed-text-v1.5/`.
 //!    Any of the ONNX variants from `nomic-ai/nomic-embed-text-v1.5` work;
 //!    the smallest usable option is `model_int8.onnx` (137 MB).
 //!    Also copy `tokenizer.json` from the same HuggingFace repo.
@@ -307,15 +307,20 @@ impl VectorManager {
         Self::new(&model_path)
     }
 
-    /// Load using the project's config (falls back to default model dir).
+    /// Load using the project's config (falls back to [`global_model_dir`]).
     ///
     /// Respects `vectors.model_dir` and `vectors.model_file` from config.toml.
+    /// Lazily migrates model files from the legacy per-project location when
+    /// the global directory has no model yet.
     pub fn from_project(project_root: &Path) -> io::Result<Self> {
         let cfg = crate::config::load_toml_config(project_root).unwrap_or_default();
         let model_dir = cfg
             .vectors
             .model_dir
-            .map_or_else(|| default_model_dir(project_root), PathBuf::from);
+            .map_or_else(global_model_dir, PathBuf::from);
+
+        maybe_migrate_legacy_model(&global_model_dir(), project_root);
+
         let model_path = find_model_file(&model_dir, cfg.vectors.model_file.as_deref())?;
         Self::new(&model_path)
     }
@@ -377,12 +382,98 @@ impl VectorManager {
     }
 }
 
-/// Default model directory: `.coraline/models/nomic-embed-text-v1.5/`.
-pub fn default_model_dir(project_root: &Path) -> PathBuf {
-    project_root
-        .join(".coraline")
+/// Shared model directory: `$XDG_CONFIG_HOME/coraline/models/nomic-embed-text-v1.5/`.
+///
+/// Falls back to `~/.config/coraline/models/nomic-embed-text-v1.5/` when
+/// `XDG_CONFIG_HOME` is not set.
+pub fn global_model_dir() -> PathBuf {
+    crate::config::global_config_dir()
         .join("models")
         .join(DEFAULT_MODEL)
+}
+
+/// Default model directory for a project.
+///
+/// Delegates to [`global_model_dir`]; `_project_root` is kept for backward
+/// compatibility but is no longer used.
+pub fn default_model_dir(_project_root: &Path) -> PathBuf {
+    global_model_dir()
+}
+
+/// Copy model files from the legacy per-project location to the shared global directory.
+///
+/// Checks `<project_root>/.coraline/models/nomic-embed-text-v1.5/` for ONNX and
+/// tokenizer files. If `global_dir` already contains any model file the function
+/// returns immediately. Prints one informational message when files are copied so
+/// users know where the model now lives and how to clean up the old location.
+pub fn maybe_migrate_legacy_model(global_dir: &Path, project_root: &Path) {
+    let already_present = MODEL_PREFERENCE_ORDER
+        .iter()
+        .any(|name| global_dir.join(name).exists());
+
+    if already_present {
+        return;
+    }
+
+    let legacy_dir = project_root
+        .join(".coraline")
+        .join("models")
+        .join(DEFAULT_MODEL);
+
+    if !legacy_dir.exists() {
+        return;
+    }
+
+    let has_model = MODEL_PREFERENCE_ORDER
+        .iter()
+        .any(|name| legacy_dir.join(name).exists());
+
+    if !has_model {
+        return;
+    }
+
+    if let Err(e) = std::fs::create_dir_all(global_dir) {
+        tracing::warn!(
+            "Model migration: could not create {}: {e}",
+            global_dir.display()
+        );
+        return;
+    }
+
+    let files_to_copy: Vec<&str> = MODEL_PREFERENCE_ORDER
+        .iter()
+        .copied()
+        .chain(["tokenizer.json", "tokenizer_config.json"])
+        .filter(|name| legacy_dir.join(name).exists())
+        .collect();
+
+    let mut copied = 0usize;
+
+    for name in &files_to_copy {
+        let src = legacy_dir.join(name);
+        let dst = global_dir.join(name);
+
+        if dst.exists() {
+            continue;
+        }
+
+        match std::fs::copy(&src, &dst) {
+            Ok(_) => copied += 1,
+            Err(e) => tracing::warn!("Model migration: failed to copy {name}: {e}"),
+        }
+    }
+
+    if copied > 0 {
+        println!(
+            "Migrated embedding model to shared location ({copied} file(s) copied).\n  \
+             From: {}\n  \
+             To:   {}\n  \
+             You can remove the old directory with: rm -rf {}",
+            legacy_dir.display(),
+            global_dir.display(),
+            legacy_dir.display(),
+        );
+    }
 }
 
 /// Mean-pool the last hidden state over non-masked positions.


### PR DESCRIPTION
Downloading the ONNX embedding model into every single `coraline`-enabled project is wasteful.
I've been test-running a patched `coraline` with global shared models for two months now without any hiccups.