### PR TITLE
chore(release): bump to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-09
+
+### Added
+
+- **Shared global config and ONNX model directory** (#78) — `~/.config/coraline/config.toml` and `~/.config/coraline/models/<model>/` are now the default locations, with the per-project `.coraline/` paths kept as a one-time migration source via `coraline model migrate`. Per-field merge: a local `[vectors]` section that only sets `enabled = true` still inherits `model_dir` from the global config. Generated embeddings and `.coraline/coraline.db` remain project-local — the share is the model weights file, not the vectors.
+- **Dual-era MCP server** (#56) — `McpServer` now serves both the upcoming-draft MCP spec (header-style `_meta` handshake) and the legacy handshake-based protocol (`2025-11-25` and earlier, including the `2025-06-18` revision this codebase originally targeted). Era is detected from the incoming `initialize` request shape, not from a pinned protocol version, so the same binary negotiates with both classes of client. `mcp/mod.rs` and `mcp/protocol.rs` split out the era dispatch from the JSON-RPC plumbing; `mcp_request` fuzz harness drives dispatch through arbitrary bytes.
+- **`.github/workflows/security-pr-base.yml`** — `pull_request_target` worker that audits the BASE branch via `cargo deny check` on every PR, satisfying the required `Check licenses and bans` status check on PRs that don't modify any dependency manifest. Explicitly checks out `${{ github.event.pull_request.base.sha }}` and never touches fork code.
+
+### Fixed
+
+- **MCP server no longer creates `.coraline/` before a project is initialized** (#71) — `McpServer` previously materialised the project directory as a side-effect of starting up, which broke tooling that distinguished "indexed" from "uninitialised" by directory presence. Initialisation now happens only on an explicit `coraline init` or on the first indexing call.
+- **`tree-sitter-markdown` upstream fork swap** (#80) — `tree-sitter-markdown-fork` → `tree-sitter-markdown-updated` to pick up maintenance fixes and avoid the unmaintained crate surfacing as a `cargo audit` warning.
+
 ### Changed
 
 - **CI action pins** — folded in 5 open dependabot version PRs:
@@ -15,10 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `github/codeql-action/upload-sarif` 4.36.2 → 4.37.3 (#75)
   - `ossf/scorecard-action` 2.4.3 → 2.4.4 (#77)
   - `softprops/action-gh-release` 3.0.0 → 3.0.2 (#73)
-  All SHA-pinned substitutions (sed-equivalent). Where this branch was on
-  a pre-bump base (e.g. v6.0.3 checkout, v3.0.0 action-gh-release, v4
-  in book.yml), the intermediate dependabot step is skipped to land
-  on the dependabot target version directly.
+    All SHA-pinned substitutions (sed-equivalent). Where this branch was on
+    a pre-bump base (e.g. v6.0.3 checkout, v3.0.0 action-gh-release, v4
+    in book.yml), the intermediate dependabot step is skipped to land
+    on the dependabot target version directly.
 - **Cargo dependency** — `tree-sitter-erlang` 0.18.0 → 0.20.0 (#79),
   skipping 0.19.0 since the branch's base predates that release.
 
@@ -491,7 +504,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Framework-specific resolvers** — Rust, React, Blazor, Laravel
 - **CLI commands** — `callers`, `callees`, `impact`, `config`, `stats`, `embed`; `--json` flag on all query commands
 - **Criterion benchmark suite** — 9 benchmarks across indexing, search, graph traversal, and context building groups (`cargo bench --bench indexing`)
-- **CI/CD** — GitHub Actions for multiplatform builds (Linux x86\_64/ARM64, macOS x86\_64/ARM64, Windows x86\_64), crates.io publishing, CodeQL scanning, daily dependency auditing
+- **CI/CD** — GitHub Actions for multiplatform builds (Linux x86_64/ARM64, macOS x86_64/ARM64, Windows x86_64), crates.io publishing, CodeQL scanning, daily dependency auditing
 - **28+ language support** via tree-sitter: Rust, TypeScript, JavaScript, TSX, JSX, Python, Go, Java, C, C++, C#, PHP, Ruby, Swift, Kotlin, Bash, Dart, Elixir, Elm, Erlang, Fortran, Groovy, Haskell, Julia, Lua, Markdown, MATLAB, Nix, Perl, PowerShell, R, Scala, TOML, YAML, Zig, Blazor
 
 ### Fixed
@@ -552,7 +565,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `coraline_search`, `coraline_callers`, `coraline_callees`, `coraline_impact`, `coraline_context` MCP tools
 - Git post-commit hook integration
 
-[Unreleased]: https://github.com/greysquirr3l/coraline/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/greysquirr3l/coraline/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/greysquirr3l/coraline/compare/v0.10.2...v0.11.0
 [0.10.2]: https://github.com/greysquirr3l/coraline/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/greysquirr3l/coraline/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/greysquirr3l/coraline/compare/v0.9.0...v0.10.0

--- a/crates/coraline/Cargo.toml
+++ b/crates/coraline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coraline"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Coraline: semantic code knowledge graph for faster AI-assisted development."
@@ -50,7 +50,7 @@ tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-ruby = "0.23"
-tree-sitter-blazor = { version = "0.1.3", path = "../tree-sitter-blazor" }
+tree-sitter-blazor = { version = "0.2.0", path = "../tree-sitter-blazor" }
 
 # Additional language parsers
 tree-sitter-bash = "0.25.1"

--- a/crates/tree-sitter-blazor/Cargo.toml
+++ b/crates/tree-sitter-blazor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-blazor"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Tree-sitter grammar for Blazor/Razor syntax"


### PR DESCRIPTION
## Release v0.11.0

Version bumps (lockstep per AGENTS.md):

- `crates/coraline` 0.10.2 → 0.11.0
- `crates/tree-sitter-blazor` 0.1.3 → 0.2.0
- `coraline` `tree-sitter-blazor` dep `^0.1.3` → `^0.2.0`

Highlights since v0.10.2 (full entries in `CHANGELOG.md`):

- Shared global config + ONNX model directory (`~/.config/coraline/`, #78)
- Dual-era MCP server supporting upcoming draft + legacy `2025-11-25` and `2025-06-18` specs (#56)
- `McpServer` no longer creates `.coraline/` prematurely (#71)
- `tree-sitter-markdown` upstream fork swap (#80)
- `security-pr-base.yml` workflow unblocks non-dep PRs (Check licenses and bans)
- `fuzz/` workspace member + ClusterFuzzLite (OSSF Scorecard Fuzzing check)
- All GH Actions SHA-pinned; workflow permissions scoped to least privilege
- `tree-sitter-erlang` 0.18.0 → 0.20.0 (#79)
- 5 dependabot action bumps folded in (#73–#77)

## Verification

- `cargo lint`: clean
- `cargo test --all-features`: 91/91 passed (9 suites)

## Release flow

After this PR merges to `main`, the `auto-tag.yml` workflow will:

1. Detect the merge to `main` and push the `v0.11.0` tag
2. `release.yml` will then build, attest, and publish the GitHub release with SLSA provenance

No manual tagging required.