### PR TITLE
fix(release): auto-tag uses gh release create (post v0.11.0 lesson)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -57,23 +57,43 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Push tag
+      - name: Create release and tag
         if: steps.gate.outputs.run == 'true' && steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.version.outputs.tag }}" -m "${{ steps.version.outputs.tag }}"
-          if git push origin "${{ steps.version.outputs.tag }}"; then
-            echo "Pushed ${{ steps.version.outputs.tag }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          SHA="${{ github.event.workflow_run.head_sha }}"
+
+          # Use gh release create instead of `git tag` + `git push`. The
+          # checkout step above uses `persist-credentials: false` (OSSF
+          # Scorecard Dangerous-Workflow fix), so a plain `git push` would
+          # fail with `could not read Username for 'https://github.com'`.
+          # `gh` re-authenticates from $GH_TOKEN for each subcommand, so
+          # the credential-persistence setting doesn't matter here.
+          #
+          # `--generate-notes` pulls PR titles + author credits from the
+          # merged commits between this tag and the previous one; release.yml
+          # overwrites the body with the curated CHANGELOG excerpt later
+          # via `gh release edit`.
+          if gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --target "$SHA" \
+              --generate-notes \
+              --title "$TAG" \
+              --verify-tag; then
+            echo "Created release $TAG"
             exit 0
           fi
 
-          # If a manual push raced us, treat that as success.
-          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
-            echo "Tag ${{ steps.version.outputs.tag }} was created concurrently; continuing"
+          # If a manual release already exists (concurrent push), treat
+          # that as success — release.yml will still run and attach the
+          # binaries.
+          if gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            echo "Release $TAG was created concurrently; continuing"
             exit 0
           fi
-          echo "Failed to push tag ${{ steps.version.outputs.tag }}"
+          echo "Failed to create release $TAG"
           exit 1
 
       - name: Tag already exists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,14 +354,41 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ needs.resolve-tag.outputs.tag }}
-          target_commitish: ${{ needs.resolve-tag.outputs.sha }}
-          body: ${{ steps.changelog.outputs.notes }}
-          files: artifacts/**/*
-          draft: false
-          prerelease: ${{ contains(needs.resolve-tag.outputs.tag, '-alpha') || contains(needs.resolve-tag.outputs.tag, '-beta') || contains(needs.resolve-tag.outputs.tag, '-rc') }}
+      - name: Create or update GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.resolve-tag.outputs.tag }}"
+          SHA="${{ needs.resolve-tag.outputs.sha }}"
+          BODY="${{ steps.changelog.outputs.notes }}"
+          PRERELEASE_FLAG=""
+          if [[ "$TAG" == *-alpha* || "$TAG" == *-beta* || "$TAG" == *-rc* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          # auto-tag.yml may have already created the release via
+          # `gh release create` (it owns the tag creation now). If so,
+          # update body and assets instead of failing on duplicate create.
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists; updating body and assets"
+            gh release edit "$TAG" --body "$BODY" $PRERELEASE_FLAG
+          else
+            echo "Creating release $TAG"
+            # No files at create time — we upload them right after.
+            gh release create "$TAG" \
+              --target "$SHA" \
+              --title "$TAG" \
+              --body "$BODY" \
+              $PRERELEASE_FLAG
+          fi
+
+          # Upload (and clobber) every artifact so re-runs don't leave stale
+          # binaries attached.
+          shopt -s globstar nullglob
+          for asset in artifacts/**/*; do
+            if [[ -f "$asset" ]]; then
+              echo "Uploading $asset"
+              gh release upload "$TAG" "$asset" --clobber
+            fi
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-09
+
+### Added
+
+- **Shared global config and ONNX model directory** (#78) — `~/.config/coraline/config.toml` and `~/.config/coraline/models/<model>/` are now the default locations, with the per-project `.coraline/` paths kept as a one-time migration source via `coraline model migrate`. Per-field merge: a local `[vectors]` section that only sets `enabled = true` still inherits `model_dir` from the global config. Generated embeddings and `.coraline/coraline.db` remain project-local — the share is the model weights file, not the vectors.
+- **Dual-era MCP server** (#56) — `McpServer` now serves both the upcoming-draft MCP spec (header-style `_meta` handshake) and the legacy handshake-based protocol (`2025-11-25` and earlier, including the `2025-06-18` revision this codebase originally targeted). Era is detected from the incoming `initialize` request shape, not from a pinned protocol version, so the same binary negotiates with both classes of client. `mcp/mod.rs` and `mcp/protocol.rs` split out the era dispatch from the JSON-RPC plumbing; `mcp_request` fuzz harness drives dispatch through arbitrary bytes.
+- **`.github/workflows/security-pr-base.yml`** — `pull_request_target` worker that audits the BASE branch via `cargo deny check` on every PR, satisfying the required `Check licenses and bans` status check on PRs that don't modify any dependency manifest. Explicitly checks out `${{ github.event.pull_request.base.sha }}` and never touches fork code.
+
+### Fixed
+
+- **MCP server no longer creates `.coraline/` before a project is initialized** (#71) — `McpServer` previously materialised the project directory as a side-effect of starting up, which broke tooling that distinguished "indexed" from "uninitialised" by directory presence. Initialisation now happens only on an explicit `coraline init` or on the first indexing call.
+- **`tree-sitter-markdown` upstream fork swap** (#80) — `tree-sitter-markdown-fork` → `tree-sitter-markdown-updated` to pick up maintenance fixes and avoid the unmaintained crate surfacing as a `cargo audit` warning.
+
 ### Changed
 
 - **CI action pins** — folded in 5 open dependabot version PRs:
@@ -15,10 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `github/codeql-action/upload-sarif` 4.36.2 → 4.37.3 (#75)
   - `ossf/scorecard-action` 2.4.3 → 2.4.4 (#77)
   - `softprops/action-gh-release` 3.0.0 → 3.0.2 (#73)
-  All SHA-pinned substitutions (sed-equivalent). Where this branch was on
-  a pre-bump base (e.g. v6.0.3 checkout, v3.0.0 action-gh-release, v4
-  in book.yml), the intermediate dependabot step is skipped to land
-  on the dependabot target version directly.
+    All SHA-pinned substitutions (sed-equivalent). Where this branch was on
+    a pre-bump base (e.g. v6.0.3 checkout, v3.0.0 action-gh-release, v4
+    in book.yml), the intermediate dependabot step is skipped to land
+    on the dependabot target version directly.
 - **Cargo dependency** — `tree-sitter-erlang` 0.18.0 → 0.20.0 (#79),
   skipping 0.19.0 since the branch's base predates that release.
 
@@ -491,7 +504,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Framework-specific resolvers** — Rust, React, Blazor, Laravel
 - **CLI commands** — `callers`, `callees`, `impact`, `config`, `stats`, `embed`; `--json` flag on all query commands
 - **Criterion benchmark suite** — 9 benchmarks across indexing, search, graph traversal, and context building groups (`cargo bench --bench indexing`)
-- **CI/CD** — GitHub Actions for multiplatform builds (Linux x86\_64/ARM64, macOS x86\_64/ARM64, Windows x86\_64), crates.io publishing, CodeQL scanning, daily dependency auditing
+- **CI/CD** — GitHub Actions for multiplatform builds (Linux x86_64/ARM64, macOS x86_64/ARM64, Windows x86_64), crates.io publishing, CodeQL scanning, daily dependency auditing
 - **28+ language support** via tree-sitter: Rust, TypeScript, JavaScript, TSX, JSX, Python, Go, Java, C, C++, C#, PHP, Ruby, Swift, Kotlin, Bash, Dart, Elixir, Elm, Erlang, Fortran, Groovy, Haskell, Julia, Lua, Markdown, MATLAB, Nix, Perl, PowerShell, R, Scala, TOML, YAML, Zig, Blazor
 
 ### Fixed
@@ -552,7 +565,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `coraline_search`, `coraline_callers`, `coraline_callees`, `coraline_impact`, `coraline_context` MCP tools
 - Git post-commit hook integration
 
-[Unreleased]: https://github.com/greysquirr3l/coraline/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/greysquirr3l/coraline/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/greysquirr3l/coraline/compare/v0.10.2...v0.11.0
 [0.10.2]: https://github.com/greysquirr3l/coraline/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/greysquirr3l/coraline/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/greysquirr3l/coraline/compare/v0.9.0...v0.10.0

--- a/crates/coraline/Cargo.toml
+++ b/crates/coraline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coraline"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Coraline: semantic code knowledge graph for faster AI-assisted development."
@@ -50,7 +50,7 @@ tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-ruby = "0.23"
-tree-sitter-blazor = { version = "0.1.3", path = "../tree-sitter-blazor" }
+tree-sitter-blazor = { version = "0.2.0", path = "../tree-sitter-blazor" }
 
 # Additional language parsers
 tree-sitter-bash = "0.25.1"

--- a/crates/tree-sitter-blazor/Cargo.toml
+++ b/crates/tree-sitter-blazor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-blazor"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Tree-sitter grammar for Blazor/Razor syntax"


### PR DESCRIPTION
## What broke

`auto-tag.yml` shipped with `persist-credentials: false` on the checkout step (OSSF Scorecard Dangerous-Workflow fix). The "Push tag" step still used `git push origin vX.Y.Z` with no other credential source — so the first release after that change (v0.11.0) saw auto-tag fail with:

```
fatal: could not read Username for 'https://github.com'
Failed to push tag v0.11.0
```

The tag and release had to be created manually via `gh release create` after the release PR was merged, defeating the auto-tag automation.

## Fix

### `.github/workflows/auto-tag.yml`

Replaces the failing `git tag` + `git push` block with `gh release create --generate-notes --verify-tag`. The `gh` CLI re-authenticates from `$GH_TOKEN` for each subcommand, so the credential-persistence setting on the checkout step is no longer load-bearing.

### `.github/workflows/release.yml`

Replaces the `softprops/action-gh-release` step with a `gh release view` + `gh release edit` / `gh release create` + upload script. Since auto-tag now creates the release first (with auto-generated notes), release.yml must UPDATE rather than CREATE — otherwise `softprops` errors on duplicate. The script:

1. Checks if the release exists
2. If yes: `gh release edit` to update the body + prerelease flag
3. If no: `gh release create` with the curated CHANGELOG excerpt
4. Uploads all `artifacts/**/*` files with `--clobber` so re-runs don't leave stale binaries attached

## Verification

I traced through both files manually — the scripts handle both fresh-release and pre-existing-release cases. Will be fully validated when the next release runs end-to-end.

Refs: tag `v0.11.0` (created manually as workaround)