### PR TITLE
v0.12.0: doctor, model validation, multi-model embeddings

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "crates/coraline/src/mcp.rs"
+      - "crates/coraline/src/mcp/**"
       - "crates/coraline/src/db.rs"
       - "crates/coraline/src/security.rs"
       - "fuzz/**"
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/cifuzz.yml"
   pull_request:
     paths:
-      - "crates/coraline/src/mcp.rs"
+      - "crates/coraline/src/mcp/**"
       - "crates/coraline/src/db.rs"
       - "crates/coraline/src/security.rs"
       - "fuzz/**"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,14 +12,14 @@ on:
   push:
     branches: [main]
     paths:
-      - "crates/coraline/src/mcp.rs"
+      - "crates/coraline/src/mcp/**"
       - "crates/coraline/src/db.rs"
       - "crates/coraline/src/security.rs"
       - "fuzz/**"
       - ".github/workflows/fuzz.yml"
   pull_request:
     paths:
-      - "crates/coraline/src/mcp.rs"
+      - "crates/coraline/src/mcp/**"
       - "crates/coraline/src/db.rs"
       - "crates/coraline/src/security.rs"
       - "fuzz/**"

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ opencode.jsonc
 RTK.md
 .claude/settings.json
 notes.txt
+TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-19
+
+### Added
+
+- **`coraline doctor`** — new diagnostic subcommand that checks config presence, database health, git hook installation, and embedding-model state, printing a `✔`/`✘` report with a remediation hint per failing check. `--quick` skips the three slow model-load/inference/embed-coverage probes (deep mode is the default); `--json` emits a machine-readable report for CI gating. Exits `0` only if every check passed.
+- **`coraline init --embed` / `--no-embed` / `--yes`** — explicit, non-interactive control over the post-init embedding-model download decision, replacing the TTY-only prompt as the sole path. `--no-embed` always wins over `--yes`; the interactive prompt remains the fallback when no flag is given and stdin is a TTY.
+- **`coraline status` embedding-model line** — status output now shows the model file (name + size) or a "not present" hint, plus the resolved model name and directory, so `coraline_semantic_search` readiness is visible without running `doctor`.
+- **Multi-model embedding support** — `vectors.model` in `config.toml` (previously present but unused) now actually selects which embedding model Coraline downloads, loads, and stores against. Ships with `nomic-embed-text-v1.5` (general-purpose, default) and `jina-embeddings-v2-base-code` (code-specialised, opt-in), both 768-dim. New `coraline model list` shows the registry; `coraline model download`/`status` accept `--model <name>` to target a non-default model (defaulting to `vectors.model` from config). Switching models on a project with existing embeddings requires re-running `coraline embed` — every read path (`coraline_semantic_search`, `doctor`'s coverage probe, staleness checks) filters by the `model` column already present in the `vectors` table schema, so a switch is self-healing rather than mixing scores across models.
+- **Structured `EMBEDDING_MODEL_MISSING` MCP error** — `coraline_semantic_search` failures from a missing/unloadable model now return a typed error envelope (`code`, `message`, `recover: { command, docs }`) in `structuredContent` instead of only free-form text, so an MCP agent can branch on `code` and act on `recover.command` directly.
+
+### Fixed
+
+- **Restored `coraline_audit_docs`, `coraline_find_file` (MCP), and `coraline audit-docs` (CLI)** — a prior refactor (`b079ac5`, config.toml consolidation) silently dropped the `tools::audit_tools` module declaration, the `FindFileTool` registration, and the `audit-docs` CLI subcommand, while leaving the fully-implemented code and its documentation in place. All three are wired back in; `docs/MCP_TOOLS.md` now lists all 35 actually-registered MCP tools (up from an undercounted 29), including the batch (`coraline_batch_*`) and advanced-search (`coraline_search_by_*`, `coraline_find_by_kind_in_file`) tool groups that were implemented but never documented. The `coraline_session_security_status` pseudo-tool, documented but removed in the same refactor (its `SessionSecurityState` tracking no longer exists on `McpServer`), and the "Background Auto-Sync" background thread, documented but never present in the current dual-era `McpServer`, are removed from the docs rather than restored — both are real feature gaps tracked separately, not doc errors.
+
 ## [0.11.0] - 2026-08-09
 
 ### Added
@@ -565,7 +579,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `coraline_search`, `coraline_callers`, `coraline_callees`, `coraline_impact`, `coraline_context` MCP tools
 - Git post-commit hook integration
 
-[Unreleased]: https://github.com/greysquirr3l/coraline/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/greysquirr3l/coraline/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/greysquirr3l/coraline/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/greysquirr3l/coraline/compare/v0.10.2...v0.11.0
 [0.10.2]: https://github.com/greysquirr3l/coraline/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/greysquirr3l/coraline/compare/v0.10.0...v0.10.1

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -22,6 +22,7 @@ When `[PATH]` is omitted, the current working directory is used as the project r
 | `impact` | Analyze change impact radius |
 | `config` | Read or update configuration |
 | `hooks` | Manage git hooks |
+| `doctor` | Run diagnostic checks (config, database, model, embed coverage) |
 | `serve` | Start the MCP server |
 | `embed` | Generate vector embeddings for indexed nodes |
 | `model` | Manage the ONNX embedding model |
@@ -32,7 +33,7 @@ When `[PATH]` is omitted, the current working directory is used as the project r
 
 Initialize Coraline in a project directory. Creates `.coraline/` with a SQLite database, default `config.toml`, and initial memory templates.
 
-When stdin is a TTY, prompts to download the embedding model (~137 MB) after initialization. Decline to skip — all non-embedding tools remain fully functional and you can download later with `coraline model download`.
+When stdin is a TTY and no model decision flag is given, prompts to download the embedding model (~137 MB) after initialization. Decline to skip — all non-embedding tools remain fully functional and you can download later with `coraline model download`. Use `--embed`, `--no-embed`, or `--yes` to make the decision non-interactively (see below); if the model is already present on disk, `init` skips the prompt entirely regardless of flags.
 
 If `.coraline/` already exists and `--index` is passed **without** `--force`, `init` skips the overwrite and runs indexing directly on the existing project.
 
@@ -43,6 +44,9 @@ If `.coraline/` already exists and `--index` is passed **without** `--force`, `i
 | `-i`, `--index` | Run a full index immediately after initialization |
 | `-f`, `--force` | Overwrite an existing `.coraline/` directory without prompting |
 | `--no-hooks` | Skip automatic git hook installation |
+| `--embed` | Download the embedding model during init (skips the TTY prompt) |
+| `--no-embed` | Skip the embedding model entirely — no prompt, no download. Conflicts with `--embed` and always wins over `--yes` |
+| `-y`, `--yes` | Non-interactive mode: auto-accept the model download prompt |
 
 **Examples:**
 ```bash
@@ -51,7 +55,12 @@ coraline init /path/to/my-app   # Initialize a specific path
 coraline init -i                 # Initialize, prompt for model, then index
 coraline init -i --no-hooks      # Initialize and index, skip git hooks
 coraline init --force            # Wipe and reinitialize existing project
+coraline init --embed            # Initialize and download the embedding model, no prompt
+coraline init --no-embed         # Initialize, skip the model entirely, no prompt
+coraline init --yes              # Initialize non-interactively; auto-downloads the model
 ```
+
+> Which model is downloaded is controlled by `vectors.model` in config (default `nomic-embed-text-v1.5`), not by an `init` flag — see `coraline model` below and the `[vectors]` section in [Configuration](configuration.md).
 
 **On success, creates:**
 - `.coraline/coraline.db` — SQLite knowledge graph
@@ -103,7 +112,7 @@ coraline sync -q                 # Silent sync (used by git hook)
 
 ## `coraline status [PATH]`
 
-Show the current project status: initialization state, paths to config and database, database size, and git hook status.
+Show the current project status: initialization state, paths to config and database, database size, embedding-model state, and git hook status.
 
 **Examples:**
 ```bash
@@ -117,8 +126,13 @@ Coraline Status
 Project: /home/user/my-app
 Config:  /home/user/my-app/.coraline/config.toml
 Database: /home/user/my-app/.coraline/coraline.db (1048576 bytes)
+Embeddings: model_quantized.onnx (161 MB)
+Model:      jina-embeddings-v2-base-code
+Model dir:  /home/user/.config/coraline/models/jina-embeddings-v2-base-code
 Git hooks: installed
 ```
+
+The `Embeddings` line shows `not present` (with a fix hint) when no model file has been downloaded yet for the project's configured model (`vectors.model`, default `nomic-embed-text-v1.5`). See `coraline model` and `coraline doctor` below.
 
 ---
 
@@ -322,6 +336,63 @@ coraline hooks remove
 
 ---
 
+## `coraline doctor [PATH]`
+
+Run diagnostic checks against a project and report pass/fail per check, with a fix hint for anything failing. Exits `0` if every check passed, `1` otherwise — safe to use as a CI gate.
+
+**Checks (in order):**
+
+| Check | What it verifies |
+|---|---|
+| `config` | `.coraline/config.toml` exists and is readable |
+| `database` | `.coraline/coraline.db` opens and returns stats (node/edge/file counts) |
+| `git hooks` | The post-commit hook is installed (or the project isn't a git repo, which is fine) |
+| `model file` | At least one ONNX variant of the configured model (`vectors.model`) is present on disk |
+| `model loads` *(deep only)* | The ONNX model actually loads into an inference session |
+| `inference` *(deep only)* | A sample embedding runs through the loaded model successfully |
+| `embed coverage` *(deep only)* | Every indexed node has an embedding for the configured model |
+
+The three deep checks require a build with the `embeddings` or `embeddings-dynamic` feature; they're skipped (not failed) on builds without it.
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--quick` | Skip the three deep model-load/inference/coverage checks (fast, no ONNX runtime needed) |
+| `--deep` | Explicit deep mode — this is already the default; mutually exclusive with `--quick` |
+| `--json` | Print the report as JSON instead of the human-readable `✔`/`✘` list |
+
+**Examples:**
+```bash
+coraline doctor                  # Full diagnostic run (deep checks included)
+coraline doctor --quick          # Skip slow model checks — good for CI
+coraline doctor --json           # Machine-readable report
+```
+
+**Sample output:**
+```
+✔  config
+✔  database
+✔  git hooks
+✘  model file
+    → Run `coraline model download`.
+```
+
+**Sample `--json` output:**
+```json
+{
+  "probes": [
+    { "name": "config", "ok": true, "detail": "/path/.coraline/config.toml (3775 bytes)" },
+    { "name": "database", "ok": true, "detail": "/path/.coraline/coraline.db (2 nodes, 1 edges, 1 files)" },
+    { "name": "git hooks", "ok": true, "detail": "installed" },
+    { "name": "model file", "ok": false, "detail": "no model file for 'nomic-embed-text-v1.5' in ...", "fix": "Run `coraline model download`." }
+  ],
+  "exit_code": 1
+}
+```
+
+---
+
 ## `coraline serve [PATH]`
 
 Start the MCP server. With `--mcp`, communicates over stdio using the Model Context Protocol.
@@ -368,38 +439,47 @@ Generate vector embeddings for all indexed nodes using the local ONNX model. Emb
 | Flag | Description |
 |---|---|
 | `--download` | Download the model automatically before embedding |
-| `--variant FILENAME` | ONNX variant to download (default: `model_int8.onnx`) |
+| `--variant FILENAME` | ONNX variant to download (default: the configured model's recommended variant) |
 | `--batch-size N` | Nodes per progress batch (default: `50`) |
 | `-q`, `--quiet` | Suppress progress output |
 
 **Examples:**
 ```bash
 coraline embed                        # Embed using already-downloaded model
-coraline embed --download             # Download model_int8.onnx then embed
+coraline embed --download             # Download the configured model then embed
 coraline embed --download --variant model_fp16.onnx
 ```
 
-Run `coraline index` first. Models are stored in `.coraline/models/nomic-embed-text-v1.5/`.
+Run `coraline index` first. Uses the model configured by `vectors.model` (default `nomic-embed-text-v1.5`), stored in `~/.config/coraline/models/<model>/` — see `coraline model list`.
 
 ---
 
 ## `coraline model [PATH]`
 
-Manage the ONNX embedding model files.
+Manage embedding model files. Supports multiple models — run `coraline model list` to see the registry.
+
+### `coraline model list`
+
+List every embedding model Coraline knows how to download and run, with dimension and description.
+
+```bash
+coraline model list
+```
 
 ### `coraline model download`
 
-Download model files from HuggingFace (`nomic-ai/nomic-embed-text-v1.5`).
+Download model files from HuggingFace.
 
 | Flag | Description |
 |---|---|
-| `--variant FILENAME` | ONNX variant to download (default: `model_int8.onnx`) |
+| `--model NAME` | Which supported model to download (default: `vectors.model` from config.toml) |
+| `--variant FILENAME` | ONNX variant to download (default: the model's recommended variant) |
 | `-f`, `--force` | Re-download even if files already exist |
 | `-q`, `--quiet` | Suppress progress output |
 
-Downloads `tokenizer.json`, `tokenizer_config.json`, and the chosen ONNX weights into `.coraline/models/nomic-embed-text-v1.5/`.
+Downloads `tokenizer.json`, `tokenizer_config.json`, and the chosen ONNX weights into the shared model directory `~/.config/coraline/models/<model>/`.
 
-**Available variants (smallest to largest):**
+**`nomic-embed-text-v1.5` variants (smallest to largest):**
 
 | Variant | Size | Notes |
 |---|---|---|
@@ -408,10 +488,28 @@ Downloads `tokenizer.json`, `tokenizer_config.json`, and the chosen ONNX weights
 | `model_fp16.onnx` | ~274 MB | fp16 |
 | `model.onnx` | ~547 MB | full f32 |
 
+**`jina-embeddings-v2-base-code` variants:**
+
+| Variant | Size | Notes |
+|---|---|---|
+| `model_quantized.onnx` | ~162 MB | int8 quantized (recommended) |
+| `model_fp16.onnx` | ~321 MB | fp16 |
+| `model.onnx` | ~642 MB | full f32 |
+
+```bash
+coraline model download                                    # download vectors.model's default variant
+coraline model download --model jina-embeddings-v2-base-code
+```
+
 ### `coraline model status`
 
-Show which model files are present in the model directory.
+Show which model files are present in the model directory for the configured (or `--model`-selected) model.
+
+| Flag | Description |
+|---|---|
+| `--model NAME` | Which supported model to inspect (default: `vectors.model` from config.toml) |
 
 ```bash
 coraline model status
+coraline model status --model jina-embeddings-v2-base-code
 ```

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -50,8 +50,8 @@ debounce_ms       = 500    # Watch mode debounce delay
 
 [vectors]
 enabled    = false                  # Requires ONNX model (see below)
-model      = "nomic-embed-text-v1.5"
-dimension  = 384
+model      = "nomic-embed-text-v1.5" # or "jina-embeddings-v2-base-code"
+dimension  = 768
 batch_size = 32
 ```
 
@@ -197,9 +197,7 @@ Debounce delay for watch mode in milliseconds.
 
 ## `[vectors]` Section
 
-Controls vector embedding generation for semantic search.
-
-> **Status:** Infrastructure is in place. Full semantic search with ONNX model embeddings is pending availability of a stable `ort` 2.0 API. Setting `enabled = true` currently has no effect.
+Controls vector embedding generation for semantic search (`coraline embed`, the `coraline_semantic_search` MCP tool). Requires a build with the `embeddings` or `embeddings-dynamic` feature.
 
 ### `enabled`
 
@@ -210,17 +208,22 @@ Enable vector embedding generation.
 
 ### `model`
 
-Embedding model identifier.
+Which embedding model to use. Run `coraline model list` to see every supported model with its dimension and description.
 
 - **Type:** string
-- **Default:** `"nomic-embed-text-v1.5"`
+- **Default:** `"nomic-embed-text-v1.5"` — general-purpose English text embeddings.
+- **Also supported:** `"jina-embeddings-v2-base-code"` — code-specialised embeddings, opt-in.
+
+Model files live in a shared directory (`~/.config/coraline/models/<model>/`, or `model_dir` below), not per-project — every project on the machine reuses the same downloaded weights for a given model. Run `coraline model download` (add `--model <name>` to target a non-default model) to fetch it.
+
+> **Switching models:** changing `model` on a project that already has embeddings does not retroactively re-embed existing nodes. Every read path (`coraline_semantic_search`, `coraline doctor`'s coverage probe, staleness checks) filters by the configured model, so a switch makes every node look unembedded for the *new* model until you re-run `coraline embed`. This is a real (if usually quick) re-embedding pass, not instant.
 
 ### `dimension`
 
-Embedding vector dimension. Must match the selected model.
+Embedding vector dimension. Must match the selected model — both currently supported models emit 768-dim vectors.
 
 - **Type:** integer
-- **Default:** `384`
+- **Default:** `768`
 
 ### `batch_size`
 
@@ -228,6 +231,25 @@ Number of symbols embedded per batch.
 
 - **Type:** integer
 - **Default:** `32`
+
+### `model_dir`
+
+Override the on-disk model directory. Unset by default — Coraline resolves it from `model` (`~/.config/coraline/models/<model>/`).
+
+- **Type:** string (path), optional
+
+### `model_file`
+
+Pin a specific ONNX filename instead of auto-detecting the best available variant for the configured `model`.
+
+- **Type:** string, optional
+
+### `max_seq_len`
+
+Maximum sequence length in tokens fed to the model.
+
+- **Type:** integer
+- **Default:** `512`
 
 ---
 

--- a/book/src/mcp-tools.md
+++ b/book/src/mcp-tools.md
@@ -1,9 +1,9 @@
 # Coraline MCP Tools Reference
 
-Coraline exposes **26 MCP tools** when running as an MCP server (`coraline serve --mcp`).
+Coraline exposes **35 MCP tools** when running as an MCP server (`coraline serve --mcp`).
 All tool names are prefixed with `coraline_` to avoid collisions with other MCP servers.
 
-`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. All other 25 tools are always available.
+`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in the shared model directory (`~/.config/coraline/models/<model>/`, where `<model>` is `vectors.model` from config, default `nomic-embed-text-v1.5`). Run `coraline model download` then `coraline embed` to activate it — see `coraline model list` for every supported model. All other 34 tools are always available.
 
 ---
 
@@ -23,9 +23,18 @@ All tool names are prefixed with `coraline_` to avoid collisions with other MCP 
 | | `coraline_get_symbols_overview` | List all symbols in a file |
 | | `coraline_find_references` | Find all references to a symbol |
 | | `coraline_node` | Get full node details and source code |
+| **Batch** | `coraline_batch_get_nodes` | Fetch multiple nodes by ID in one call |
+| | `coraline_batch_callers` | Get callers for multiple symbols in one call |
+| | `coraline_batch_callees` | Get callees for multiple symbols in one call |
+| **Advanced Search** | `coraline_search_by_signature` | Find symbols by type signature pattern |
+| | `coraline_search_by_docstring` | Find symbols by documentation/comment content |
+| | `coraline_search_exported_symbols` | Search only public/exported symbols |
+| | `coraline_find_by_kind_in_file` | Get all symbols of a kind in one file |
 | **Context** | `coraline_context` | Build structured context for an AI task |
+| **Audit** | `coraline_audit_docs` | Audit Markdown docs for stale references and undocumented exports |
 | **File** | `coraline_read_file` | Read file contents |
 | | `coraline_list_dir` | List directory contents |
+| | `coraline_find_file` | Find files by glob pattern |
 | | `coraline_get_file_nodes` | Get all indexed nodes in a file |
 | | `coraline_status` | Show project index statistics |
 | | `coraline_sync` | Trigger incremental index sync |
@@ -310,6 +319,119 @@ Get complete details for a specific node by ID, including its source code body r
 
 ---
 
+## Batch Tools
+
+Fetch results for multiple symbols in one call instead of N round trips — roughly 60% fewer tokens than the equivalent sequence of single-symbol calls.
+
+### `coraline_batch_get_nodes`
+
+Fetch multiple nodes by ID in a single call.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `node_ids` | array of string | ✅ | — | Node IDs to fetch |
+| `include_body` | boolean | | `false` | Include source code body for each node |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+**Output:** `{ "nodes": [...], "count": N, "not_found": [...] }`
+
+---
+
+### `coraline_batch_callers`
+
+Get callers for multiple symbols in a single call.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `node_ids` | array of string | ✅ | — | Node IDs to find callers for |
+| `limit_per_node` | number | | `20` | Maximum callers to return per node |
+
+**Output:** `{ "callers": { "<node_id>": [...] }, "node_count": N }`
+
+---
+
+### `coraline_batch_callees`
+
+Get callees for multiple symbols in a single call.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `node_ids` | array of string | ✅ | — | Node IDs to find callees for |
+| `limit_per_node` | number | | `20` | Maximum callees to return per node |
+
+**Output:** `{ "callees": { "<node_id>": [...] }, "node_count": N }`
+
+---
+
+## Advanced Search Tools
+
+Specialized lookups over indexed nodes, faster than full-text `coraline_search` for these specific shapes — also roughly 60% fewer tokens for the matched use case.
+
+### `coraline_search_by_signature`
+
+Find symbols by type signature pattern (case-insensitive substring match) — e.g. functions by return type or parameters.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `pattern` | string | ✅ | — | Signature substring to search for (e.g. `"Result<"`, `"async fn"`, `"<T>"`) |
+| `kind` | string | | — | Filter: `function`, `method`, `class`, `struct`, `interface`, `trait` |
+| `limit` | number | | `20` | Maximum results |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
+### `coraline_search_by_docstring`
+
+Search symbols by documentation/comment content — find code by what it does, not just its name.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | ✅ | — | Text to search for in docstrings/comments |
+| `kind` | string | | — | Filter: `function`, `method`, `class`, `struct`, `interface`, `trait` |
+| `limit` | number | | `20` | Maximum results |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
+### `coraline_search_exported_symbols`
+
+Search only public/exported symbols — filters out internal implementation details to browse the public API surface.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | ✅ | — | Symbol name pattern; use `"*"` to list all |
+| `kind` | string | | — | Filter: `function`, `method`, `class`, `struct`, `interface`, `trait`, `module` |
+| `limit` | number | | `20` | Maximum results |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
+### `coraline_find_by_kind_in_file`
+
+Get all symbols of a specific kind in one file — fast file-scoped exploration.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `file_path` | string | ✅ | — | Path to the file (relative to project root) |
+| `kind` | string | ✅ | — | `function`, `method`, `class`, `struct`, `interface`, `trait`, `module`, `constant`, or `variable` |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
 ## Context Tool
 
 ### `coraline_context`
@@ -329,6 +451,56 @@ Build structured context for an AI task description. Searches the graph, travers
 | `format` | string | | `"markdown"` | `"markdown"` or `"json"` |
 
 **Output:** A Markdown or JSON document containing relevant symbols and code, ready to paste as context for an LLM.
+
+---
+
+## Audit Tool
+
+### `coraline_audit_docs`
+
+Audit Markdown documentation coverage against the indexed code graph.
+
+Detects two classes of issues:
+- `stale_refs`: inline code-span symbol references in Markdown that do not resolve to indexed symbols
+- `undocumented_exports`: exported code symbols with no inbound `references` edge from Markdown docs
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `show_undocumented` | boolean | | `true` | Include undocumented export results |
+| `show_stale` | boolean | | `true` | Include stale reference results |
+| `limit` | number | | `50` | Max items returned per result set |
+
+**Output:**
+```json
+{
+  "summary": {
+    "doc_files_indexed": 12,
+    "doc_sections_indexed": 89,
+    "stale_refs_count": 3,
+    "undocumented_exports_count": 7
+  },
+  "stale_refs": [
+    {
+      "reference": "resolve_unresolved",
+      "doc_file": "docs/ARCHITECTURE.md",
+      "section": "Resolution",
+      "line": 42,
+      "column": 18
+    }
+  ],
+  "undocumented_exports": [
+    {
+      "name": "audit_docs",
+      "qualified_name": "coraline::audit::audit_docs",
+      "kind": "function",
+      "file": "crates/coraline/src/audit.rs",
+      "line": 48
+    }
+  ]
+}
+```
 
 ---
 
@@ -372,6 +544,28 @@ Get all indexed symbols (nodes) for a specific file.
 | `file_path` | string | ✅ | File path (relative or absolute) |
 
 **Output:** `{ "file_path": "...", "nodes": [...], "count": N }`
+
+---
+
+### `coraline_find_file`
+
+Find files by name or glob pattern. Recursively walks the project tree, skipping `.git`, `node_modules`, `target`, and `.coraline` directories.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `pattern` | string | ✅ | — | File name, substring, or glob pattern (`*.rs`, `test_*`, `[Cc]argo.toml`) |
+| `limit` | number | | `20` | Maximum results |
+
+**Output:**
+```json
+{
+  "pattern": "*.rs",
+  "files": ["src/lib.rs", "src/db.rs", "src/graph.rs"],
+  "count": 3
+}
+```
 
 ---
 
@@ -439,11 +633,28 @@ Trigger an incremental sync of the index. Detects files added, modified, or remo
 
 ### `coraline_semantic_search`
 
-Search indexed nodes using natural-language vector similarity. Included in the default build; only registered as an MCP tool once an ONNX model is present in `.coraline/models/`. To activate:
+Search indexed nodes using natural-language vector similarity. Included in the default build; only registered as an MCP tool once an ONNX model is present in the shared model directory (`~/.config/coraline/models/<model>/`, `<model>` from `vectors.model`). To activate:
 
 ```bash
-coraline model download   # download nomic-embed-text-v1.5 (~137 MB)
+coraline model download   # download the configured model (default nomic-embed-text-v1.5, ~137 MB)
 coraline embed            # generate embeddings for all indexed nodes
+```
+
+Run `coraline model list` to see every supported model, including the code-specialised `jina-embeddings-v2-base-code`. Results and coverage are scoped to whichever model is currently configured — embeddings from a previously-configured model are ignored, not mixed in.
+
+**Structured error when the model is missing:**
+
+If the ONNX model can't be loaded (not downloaded yet, or `tokenizer.json`/weights missing), the tool call fails with `isError: true` and a structured `EMBEDDING_MODEL_MISSING` envelope in `structuredContent`, so an agent can branch on `code` instead of parsing free-form text:
+
+```json
+{
+  "code": "EMBEDDING_MODEL_MISSING",
+  "message": "Embedding model is not present. Run `coraline model download` to download it.",
+  "recover": {
+    "command": "coraline model download",
+    "docs": "https://github.com/greysquirr3l/coraline#embeddings (debug: load failed: ...)"
+  }
+}
 ```
 
 **Input:**

--- a/crates/coraline/Cargo.toml
+++ b/crates/coraline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coraline"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Coraline: semantic code knowledge graph for faster AI-assisted development."

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -2047,7 +2047,7 @@ mod tests {
             std::fs::create_dir_all(&coraline_dir)?;
             let custom_dir = root.join("custom-models");
             std::fs::create_dir_all(&custom_dir)?;
-            let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom_dir.display());
+            let config = format!("[vectors]\nmodel_dir = '{}'\n", custom_dir.display());
             std::fs::write(coraline_dir.join("config.toml"), config)?;
 
             let (_, resolved) = doctor::resolve_status_model(root);

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use coraline::config;
 use coraline::context;
 use coraline::db;
+use coraline::doctor;
 use coraline::extraction;
 use coraline::logging;
 use coraline::mcp::McpServer;
@@ -35,6 +36,7 @@ enum Command {
     Sync(SyncArgs),
     Status(StatusArgs),
     Stats(StatsArgs),
+    Doctor(DoctorArgs),
     Query(QueryArgs),
     Context(ContextArgs),
     Callers(CallersArgs),
@@ -96,6 +98,21 @@ struct SyncArgs {
 #[derive(Debug, Args)]
 struct StatusArgs {
     path: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct DoctorArgs {
+    /// Project root (defaults to current directory).
+    path: Option<PathBuf>,
+    /// Skip slow model-load + inference probes.
+    #[arg(long = "quick", conflicts_with = "deep")]
+    quick: bool,
+    /// Explicit deep mode (default): include model load + inference + coverage probes.
+    #[arg(long = "deep", conflicts_with = "quick")]
+    deep: bool,
+    /// Output report as JSON for machine consumption.
+    #[arg(long = "json")]
+    json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -283,6 +300,7 @@ fn main() {
         Command::Sync(a) => a.path.clone(),
         Command::Status(a) => a.path.clone(),
         Command::Stats(a) => a.path.clone(),
+        Command::Doctor(a) => a.path.clone(),
         Command::Query(a) => a.path.clone(),
         Command::Context(a) => a.path.clone(),
         Command::Callers(a) => a.path.clone(),
@@ -318,6 +336,7 @@ fn main() {
         Command::Sync(args) => run_sync(args),
         Command::Status(args) => run_status(args),
         Command::Stats(args) => run_stats(args),
+        Command::Doctor(args) => run_doctor(args),
         Command::Query(args) => run_query(args),
         Command::Context(args) => run_context(args),
         Command::Callers(args) => run_callers(args),
@@ -1028,16 +1047,16 @@ fn run_status(args: StatusArgs) {
     println!("Config:  {}", cfg_path.display());
     println!("Database: {} ({} bytes)", db_path.display(), db_size);
 
-    let model_dir = resolve_status_model_dir(&project_root);
-    match compute_model_state(&model_dir) {
-        ModelState::Present {
+    let model_dir = doctor::resolve_status_model_dir(&project_root);
+    match doctor::compute_model_state(&model_dir) {
+        doctor::ModelState::Present {
             ref name,
             size_bytes,
         } => {
             let size_mb = size_bytes / 1_000_000;
             println!("Embeddings: {name} ({size_mb} MB)");
         }
-        ModelState::Absent => {
+        doctor::ModelState::Absent => {
             println!("Embeddings: not present");
             println!("            Run `coraline model download` to enable semantic search.");
         }
@@ -1056,37 +1075,50 @@ fn run_status(args: StatusArgs) {
     }
 }
 
-/// Resolve the embedding-model directory for the given project, honouring
-/// `vectors.model_dir` in `config.toml` when set, falling back to the global
-/// default (`~/.config/coraline/models/nomic-embed-text-v1.5/`).
-fn resolve_status_model_dir(project_root: &Path) -> PathBuf {
-    let cfg = config::load_toml_config(project_root).unwrap_or_default();
-    cfg.vectors
-        .model_dir
-        .map_or_else(|| vectors::default_model_dir(project_root), PathBuf::from)
+fn run_doctor(args: DoctorArgs) {
+    let project_root = resolve_project_root(args.path);
+    let deep = !args.quick;
+    let report = doctor::run_all(&project_root, deep);
+
+    if args.json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(json) => println!("{json}"),
+            Err(e) => {
+                eprintln!("Failed to serialize report: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        print_doctor_report(&report, deep);
+    }
+
+    std::process::exit(report.exit_code);
 }
 
-/// Pure lookup of which (if any) model variant is present on disk.
-fn compute_model_state(model_dir: &Path) -> ModelState {
-    for name in vectors::MODEL_PREFERENCE_ORDER {
-        let p = model_dir.join(name);
-        if let Ok(meta) = std::fs::metadata(&p) {
-            return ModelState::Present {
-                name: (*name).to_string(),
-                size_bytes: meta.len(),
-            };
+fn print_doctor_report(report: &doctor::Report, deep: bool) {
+    if deep {
+        let pb = spinner_indefinite("Running doctor probes…");
+        for probe in &report.probes {
+            let mark = if probe.ok { "✔" } else { "✘" };
+            pb.println(format!("{mark}  {}", probe.name));
+            if !probe.ok
+                && let Some(fix) = &probe.fix
+            {
+                pb.println(format!("    → {fix}"));
+            }
+        }
+        pb.finish_and_clear();
+    } else {
+        for probe in &report.probes {
+            let mark = if probe.ok { "✔" } else { "✘" };
+            println!("{mark}  {}", probe.name);
+            if !probe.ok
+                && let Some(fix) = &probe.fix
+            {
+                println!("    → {fix}");
+            }
         }
     }
-    ModelState::Absent
-}
-
-/// Embedding-model state, as surfaced by `coraline status`.
-#[derive(Debug, PartialEq, Eq)]
-enum ModelState {
-    /// At least one variant in `MODEL_PREFERENCE_ORDER` is present.
-    Present { name: String, size_bytes: u64 },
-    /// No model file exists in the directory.
-    Absent,
 }
 
 fn run_query(args: QueryArgs) {
@@ -1746,8 +1778,8 @@ mod tests {
     #[test]
     fn model_state_absent_when_no_files() -> TestResult {
         let temp_dir = tempfile::TempDir::new()?;
-        let state = compute_model_state(temp_dir.path());
-        assert_eq!(state, ModelState::Absent);
+        let state = doctor::compute_model_state(temp_dir.path());
+        assert_eq!(state, doctor::ModelState::Absent);
         Ok(())
     }
 
@@ -1755,28 +1787,12 @@ mod tests {
     fn model_state_present_picks_first_preferred_variant() -> TestResult {
         let temp_dir = tempfile::TempDir::new()?;
         std::fs::write(temp_dir.path().join("model_int8.onnx"), vec![0u8; 42])?;
-        let state = compute_model_state(temp_dir.path());
+        let state = doctor::compute_model_state(temp_dir.path());
         assert_eq!(
             state,
-            ModelState::Present {
+            doctor::ModelState::Present {
                 name: "model_int8.onnx".to_string(),
                 size_bytes: 42,
-            }
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn model_state_present_records_actual_size() -> TestResult {
-        let temp_dir = tempfile::TempDir::new()?;
-        let bytes = vec![0u8; 1_500_000];
-        std::fs::write(temp_dir.path().join("model_int8.onnx"), &bytes)?;
-        let state = compute_model_state(temp_dir.path());
-        assert_eq!(
-            state,
-            ModelState::Present {
-                name: "model_int8.onnx".to_string(),
-                size_bytes: 1_500_000,
             }
         );
         Ok(())
@@ -1793,7 +1809,7 @@ mod tests {
         let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom_dir.display());
         std::fs::write(coraline_dir.join("config.toml"), config)?;
 
-        let resolved = resolve_status_model_dir(root);
+        let resolved = doctor::resolve_status_model_dir(root);
         assert_eq!(resolved, custom_dir);
         Ok(())
     }

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -1,6 +1,10 @@
-#![allow(clippy::multiple_crate_versions)]
+#![expect(
+    clippy::multiple_crate_versions,
+    reason = "transitive dependency version conflicts we can't control (base64, getrandom, hashbrown)"
+)]
 use std::path::{Path, PathBuf};
 
+use coraline::audit;
 use coraline::config;
 use coraline::context;
 use coraline::db;
@@ -45,6 +49,8 @@ enum Command {
     Config(ConfigArgs),
     Hooks(HooksArgs),
     Serve(ServeArgs),
+    /// Audit documentation accuracy and coverage against the code graph.
+    AuditDocs(AuditDocsArgs),
     #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
     Embed(EmbedArgs),
     #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
@@ -230,6 +236,24 @@ struct ServeArgs {
     timeout_ms: u64,
 }
 
+#[derive(Debug, Args)]
+struct AuditDocsArgs {
+    #[arg(short = 'p', long = "path")]
+    path: Option<PathBuf>,
+    /// Hide stale-reference findings.
+    #[arg(long = "no-stale")]
+    no_stale: bool,
+    /// Hide undocumented-export findings.
+    #[arg(long = "no-undocumented")]
+    no_undocumented: bool,
+    /// Maximum items to display per category.
+    #[arg(short = 'l', long = "limit", default_value_t = 50)]
+    limit: usize,
+    /// Output raw JSON instead of formatted text.
+    #[arg(short = 'j', long = "json")]
+    json: bool,
+}
+
 #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 #[derive(Debug, Args)]
 struct EmbedArgs {
@@ -244,9 +268,10 @@ struct EmbedArgs {
     /// Download the model from `HuggingFace` if not already present.
     #[arg(long = "download")]
     download: bool,
-    /// ONNX variant to download when using `--download` (default: `model_int8.onnx`).
-    #[arg(long = "variant", default_value = "model_int8.onnx")]
-    variant: String,
+    /// ONNX variant to download when using `--download`.
+    /// Defaults to the configured model's recommended variant.
+    #[arg(long = "variant")]
+    variant: Option<String>,
 }
 
 #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
@@ -266,20 +291,35 @@ struct ModelArgs {
 enum ModelAction {
     /// Download model files from `HuggingFace` (tokenizer + ONNX weights).
     Download {
+        /// Which supported model to download (see `coraline model list`).
+        /// Defaults to `vectors.model` from config.toml.
+        #[arg(long = "model")]
+        model: Option<String>,
         /// ONNX variant filename to download.
-        #[arg(long = "variant", default_value = "model_int8.onnx")]
-        variant: String,
+        /// Defaults to the model's recommended variant.
+        #[arg(long = "variant")]
+        variant: Option<String>,
         /// Re-download even if the file already exists.
         #[arg(short = 'f', long = "force")]
         force: bool,
     },
     /// Show which model files are present in the model directory.
-    Status,
+    Status {
+        /// Which supported model to inspect. Defaults to `vectors.model`.
+        #[arg(long = "model")]
+        model: Option<String>,
+    },
     /// Copy model files from the legacy per-project location to the shared global directory.
     ///
     /// The legacy location is `.coraline/models/nomic-embed-text-v1.5/` inside the
     /// project root. After migration the old directory can be removed manually.
+    ///
+    /// This is deliberately nomic-only: the legacy per-project layout predates
+    /// multi-model support entirely, so there is nothing to migrate for any
+    /// other model.
     Migrate,
+    /// List every embedding model Coraline knows how to download and run.
+    List,
 }
 
 fn main() {
@@ -309,6 +349,7 @@ fn main() {
         Command::Config(a) => a.path.clone(),
         Command::Hooks(a) => a.path.clone(),
         Command::Serve(a) => a.path.clone(),
+        Command::AuditDocs(a) => a.path.clone(),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Embed(a) => a.path.clone(),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
@@ -359,6 +400,7 @@ fn main() {
                 println!("Use --mcp to start the MCP server.");
             }
         }
+        Command::AuditDocs(args) => run_audit_docs(args),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
         Command::Embed(args) => run_embed(args),
         #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
@@ -366,35 +408,61 @@ fn main() {
     }
 }
 
+/// Resolve which model a `coraline model` subcommand should act on: the
+/// `--model` flag if given, else `vectors.model` from config.toml.
 #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-fn run_model(args: ModelArgs) {
-    let project_root = resolve_project_root(args.path);
-    let cfg = config::load_toml_config(&project_root).unwrap_or_default();
-    let model_dir = cfg
-        .vectors
-        .model_dir
-        .map_or_else(vectors::global_model_dir, PathBuf::from);
+fn resolve_action_model(project_root: &Path, model_flag: Option<&str>) -> (String, PathBuf) {
+    let mut cfg = config::load_toml_config(project_root).unwrap_or_default();
+    if let Some(m) = model_flag {
+        cfg.vectors.model = m.to_string();
+        cfg.vectors.model_dir = None;
+    }
+    vectors::resolve_model_dir(&cfg.vectors)
+        .unwrap_or_else(|_| (cfg.vectors.model.clone(), vectors::global_model_dir()))
+}
 
-    // Lazily migrate any model files found in the legacy per-project location.
-    vectors::maybe_migrate_legacy_model(&vectors::global_model_dir(), &project_root);
-
-    match args.action {
-        ModelAction::Download { variant, force } => {
-            if !args.quiet {
-                println!("Downloading {variant} into {} ...", model_dir.display());
-            }
-            if let Err(e) = vectors::download_model(&model_dir, &variant, !force, args.quiet) {
-                eprintln!("Download failed: {e}");
-                std::process::exit(1);
-            }
-            if !args.quiet {
-                println!("Done. Run `coraline embed` to generate embeddings.");
-            }
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+fn run_model_download(
+    project_root: &Path,
+    quiet: bool,
+    model: Option<&str>,
+    variant: Option<String>,
+    force: bool,
+) {
+    let (model_name, model_dir) = resolve_action_model(project_root, model);
+    let spec = match vectors::model_spec(&model_name) {
+        Ok(spec) => spec,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
         }
-        ModelAction::Status => {
-            println!("Model directory: {}", model_dir.display());
-            println!();
-            for name in vectors::MODEL_PREFERENCE_ORDER {
+    };
+    let variant = variant.unwrap_or_else(|| spec.default_filename.to_string());
+
+    if !quiet {
+        println!(
+            "Downloading {model_name} ({variant}) into {} ...",
+            model_dir.display()
+        );
+    }
+    if let Err(e) = vectors::download_model(&model_name, &model_dir, &variant, !force, quiet) {
+        eprintln!("Download failed: {e}");
+        std::process::exit(1);
+    }
+    if !quiet {
+        println!("Done. Run `coraline embed` to generate embeddings.");
+    }
+}
+
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+fn run_model_status(project_root: &Path, model: Option<&str>) {
+    let (model_name, model_dir) = resolve_action_model(project_root, model);
+    println!("Model:           {model_name}");
+    println!("Model directory: {}", model_dir.display());
+    println!();
+    match vectors::model_spec(&model_name) {
+        Ok(spec) => {
+            for name in spec.preference_order {
                 let p = model_dir.join(name);
                 if let Ok(meta) = std::fs::metadata(&p) {
                     println!("  {name:<30}  {:>6} MB  [present]", meta.len() / 1_000_000);
@@ -402,57 +470,99 @@ fn run_model(args: ModelArgs) {
                     println!("  {name:<30}  (not present)");
                 }
             }
-            println!();
-            for name in &["tokenizer.json", "tokenizer_config.json"] {
-                let p = model_dir.join(name);
-                if p.exists() {
-                    println!("  {name:<30}  [present]");
-                } else {
-                    println!("  {name:<30}  (not present)");
-                }
-            }
         }
-        ModelAction::Migrate => {
-            let global_dir = vectors::global_model_dir();
-            let legacy_dir = project_root
-                .join(".coraline")
-                .join("models")
-                .join(vectors::DEFAULT_MODEL);
-
-            let global_has_model = vectors::MODEL_PREFERENCE_ORDER
-                .iter()
-                .any(|name| global_dir.join(name).exists());
-
-            if global_has_model {
-                println!(
-                    "Shared model directory already populated: {}",
-                    global_dir.display()
-                );
-                println!("Nothing to migrate.");
-
-                return;
-            }
-
-            let legacy_has_model = vectors::MODEL_PREFERENCE_ORDER
-                .iter()
-                .any(|name| legacy_dir.join(name).exists());
-
-            if !legacy_has_model {
-                println!(
-                    "No model files found in legacy location: {}",
-                    legacy_dir.display()
-                );
-                println!(
-                    "Run `coraline model download` to fetch the model into {}",
-                    global_dir.display()
-                );
-
-                return;
-            }
-
-            // The lazy migration function prints its own message when files are copied.
-            vectors::maybe_migrate_legacy_model(&global_dir, &project_root);
+        Err(e) => eprintln!("{e}"),
+    }
+    println!();
+    for name in &["tokenizer.json", "tokenizer_config.json"] {
+        let p = model_dir.join(name);
+        if p.exists() {
+            println!("  {name:<30}  [present]");
+        } else {
+            println!("  {name:<30}  (not present)");
         }
+    }
+}
+
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+fn run_model_migrate(project_root: &Path) {
+    let global_dir = vectors::global_model_dir();
+    let legacy_dir = project_root
+        .join(".coraline")
+        .join("models")
+        .join(vectors::DEFAULT_MODEL);
+
+    let global_has_model = vectors::MODEL_PREFERENCE_ORDER
+        .iter()
+        .any(|name| global_dir.join(name).exists());
+
+    if global_has_model {
+        println!(
+            "Shared model directory already populated: {}",
+            global_dir.display()
+        );
+        println!("Nothing to migrate.");
+
+        return;
+    }
+
+    let legacy_has_model = vectors::MODEL_PREFERENCE_ORDER
+        .iter()
+        .any(|name| legacy_dir.join(name).exists());
+
+    if !legacy_has_model {
+        println!(
+            "No model files found in legacy location: {}",
+            legacy_dir.display()
+        );
+        println!(
+            "Run `coraline model download` to fetch the model into {}",
+            global_dir.display()
+        );
+
+        return;
+    }
+
+    // The lazy migration function prints its own message when files are copied.
+    vectors::maybe_migrate_legacy_model(&global_dir, project_root);
+}
+
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+fn run_model_list() {
+    println!("Supported embedding models:\n");
+    for spec in vectors::SUPPORTED_MODELS {
+        let default_marker = if spec.name == vectors::DEFAULT_MODEL {
+            " (default)"
+        } else {
+            ""
+        };
+        println!("  {}{}", spec.name, default_marker);
+        println!("    {}", spec.description);
+        println!(
+            "    dimension: {}, default variant: {}",
+            spec.dimension, spec.default_filename
+        );
+        println!();
+    }
+}
+
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+fn run_model(args: ModelArgs) {
+    let project_root = resolve_project_root(args.path);
+
+    // Lazily migrate any nomic model files found in the legacy per-project
+    // location (deliberately nomic-only, see `ModelAction::Migrate` docs).
+    vectors::maybe_migrate_legacy_model(&vectors::global_model_dir(), &project_root);
+
+    match args.action {
+        ModelAction::Download {
+            model,
+            variant,
+            force,
+        } => run_model_download(&project_root, args.quiet, model.as_deref(), variant, force),
+        ModelAction::Status { model } => run_model_status(&project_root, model.as_deref()),
+        ModelAction::Migrate => run_model_migrate(&project_root),
+        ModelAction::List => run_model_list(),
     }
 }
 
@@ -467,19 +577,25 @@ fn run_embed(args: EmbedArgs) {
 
     // Auto-download model files if requested.
     if args.download {
-        let cfg = config::load_toml_config(&project_root).unwrap_or_default();
-        let model_dir = cfg
-            .vectors
-            .model_dir
-            .map_or_else(|| vectors::default_model_dir(&project_root), PathBuf::from);
+        let (model_name, model_dir) = resolve_action_model(&project_root, None);
+        let variant = match vectors::model_spec(&model_name) {
+            Ok(spec) => args
+                .variant
+                .clone()
+                .unwrap_or_else(|| spec.default_filename.to_string()),
+            Err(e) => {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        };
         if !args.quiet {
             println!(
-                "Downloading {} into {} ...",
-                args.variant,
+                "Downloading {model_name} ({variant}) into {} ...",
                 model_dir.display()
             );
         }
-        if let Err(e) = vectors::download_model(&model_dir, &args.variant, true, args.quiet) {
+        if let Err(e) = vectors::download_model(&model_name, &model_dir, &variant, true, args.quiet)
+        {
             eprintln!("Download failed: {e}");
             std::process::exit(1);
         }
@@ -540,9 +656,10 @@ fn load_embedding_model(project_root: &Path, quiet: bool) -> vectors::VectorMana
     };
     result.unwrap_or_else(|err| {
         eprintln!("Failed to load model: {err}");
+        let (_, model_dir) = resolve_action_model(project_root, None);
         eprintln!(
-            "Download model.onnx + tokenizer.json into {}",
-            vectors::default_model_dir(project_root).display()
+            "Download model.onnx + tokenizer.json into {} (or run `coraline model download`)",
+            model_dir.display()
         );
         std::process::exit(1);
     })
@@ -820,10 +937,12 @@ mod init_model {
     /// model is already on disk. All non-embedding tools remain fully
     /// functional regardless of the chosen action.
     pub fn handle_model_decision(project_root: &Path, embed: bool, no_embed: bool, yes: bool) {
-        let model_dir = resolve_model_dir(project_root);
-        let model_present = vectors::MODEL_PREFERENCE_ORDER
-            .iter()
-            .any(|name| model_dir.join(name).exists());
+        let (model_name, model_dir) = resolve_configured_model(project_root);
+        let model_present = vectors::model_spec(&model_name).is_ok_and(|spec| {
+            spec.preference_order
+                .iter()
+                .any(|name| model_dir.join(name).exists())
+        });
         let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
         let inputs = ModelInputs {
             model_present,
@@ -878,16 +997,17 @@ mod init_model {
         ModelAction::Hint
     }
 
-    pub fn resolve_model_dir(project_root: &Path) -> PathBuf {
+    /// Resolve the configured model name and its on-disk directory
+    /// (`vectors.model` / `vectors.model_dir` from config.toml).
+    pub fn resolve_configured_model(project_root: &Path) -> (String, PathBuf) {
         let cfg = config::load_toml_config(project_root).unwrap_or_default();
-        cfg.vectors
-            .model_dir
-            .map_or_else(|| vectors::default_model_dir(project_root), PathBuf::from)
+        vectors::resolve_model_dir(&cfg.vectors)
+            .unwrap_or_else(|_| (cfg.vectors.model.clone(), vectors::global_model_dir()))
     }
 
     pub fn execute_model_action(project_root: &Path, action: &ModelAction) {
         use std::io::Write as _;
-        let model_dir = resolve_model_dir(project_root);
+        let (model_name, model_dir) = resolve_configured_model(project_root);
 
         match action {
             ModelAction::NoOp => {}
@@ -895,7 +1015,7 @@ mod init_model {
                 println!("Skipped. Run `coraline model download` later to enable semantic search.");
             }
             ModelAction::Download => {
-                download_model_and_report(&model_dir);
+                download_model_and_report(&model_name, &model_dir);
             }
             ModelAction::Prompt => {
                 eprint!("Download embedding model for semantic search? (~137 MB) [Y/n] ");
@@ -906,7 +1026,7 @@ mod init_model {
                 }
                 let answer = input.trim();
                 if answer.is_empty() || answer.eq_ignore_ascii_case("y") {
-                    download_model_and_report(&model_dir);
+                    download_model_and_report(&model_name, &model_dir);
                 } else {
                     println!(
                         "Skipped. Run `coraline model download` later to enable semantic search."
@@ -921,9 +1041,13 @@ mod init_model {
         }
     }
 
-    fn download_model_and_report(model_dir: &Path) {
-        println!("Downloading model into {} ...", model_dir.display());
-        match vectors::download_model(model_dir, "model_int8.onnx", true, false) {
+    fn download_model_and_report(model_name: &str, model_dir: &Path) {
+        let Ok(spec) = vectors::model_spec(model_name) else {
+            eprintln!("Unknown embedding model '{model_name}'.");
+            return;
+        };
+        println!("Downloading {model_name} into {} ...", model_dir.display());
+        match vectors::download_model(model_name, model_dir, spec.default_filename, true, false) {
             Ok(()) => println!("Done. Run `coraline embed` to generate embeddings."),
             Err(e) => {
                 eprintln!("Model download failed: {e}");
@@ -1047,8 +1171,8 @@ fn run_status(args: StatusArgs) {
     println!("Config:  {}", cfg_path.display());
     println!("Database: {} ({} bytes)", db_path.display(), db_size);
 
-    let model_dir = doctor::resolve_status_model_dir(&project_root);
-    match doctor::compute_model_state(&model_dir) {
+    let (model_name, model_dir) = doctor::resolve_status_model(&project_root);
+    match doctor::compute_model_state(&model_dir, &model_name) {
         doctor::ModelState::Present {
             ref name,
             size_bytes,
@@ -1061,6 +1185,7 @@ fn run_status(args: StatusArgs) {
             println!("            Run `coraline model download` to enable semantic search.");
         }
     }
+    println!("Model:      {model_name}");
     println!("Model dir:  {}", model_dir.display());
 
     let hooks = GitHooksManager::new(&project_root);
@@ -1239,6 +1364,109 @@ fn run_hooks_status(path: Option<PathBuf>) {
         println!("Git hook is installed.");
     } else {
         println!("Git hook is not installed.");
+    }
+}
+
+fn run_audit_docs(args: AuditDocsArgs) {
+    let project_root = resolve_project_root(args.path);
+
+    let report = match audit::audit_docs(&project_root) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to run doc audit: {e}");
+            eprintln!("Make sure the project has been indexed (`coraline index`).");
+            std::process::exit(1);
+        }
+    };
+
+    if args.json {
+        let stale: Vec<_> = report
+            .stale_refs
+            .iter()
+            .take(args.limit)
+            .map(|r| {
+                serde_json::json!({
+                    "reference": r.reference_name,
+                    "doc_file": r.doc_file,
+                    "section": r.doc_section,
+                    "line": r.line,
+                    "column": r.column
+                })
+            })
+            .collect();
+        let undoc: Vec<_> = report
+            .undocumented_exports
+            .iter()
+            .take(args.limit)
+            .map(|u| {
+                serde_json::json!({
+                    "name": u.name,
+                    "qualified_name": u.qualified_name,
+                    "kind": u.kind,
+                    "file": u.file_path,
+                    "line": u.start_line
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "doc_files_indexed": report.doc_files_indexed,
+            "doc_sections_indexed": report.doc_sections_indexed,
+            "stale_refs": stale,
+            "undocumented_exports": undoc
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
+        return;
+    }
+
+    // Human-readable output
+    println!(
+        "Doc audit — {} file(s), {} section(s) indexed\n",
+        report.doc_files_indexed, report.doc_sections_indexed
+    );
+
+    if !args.no_stale {
+        let total = report.stale_refs.len();
+        if total == 0 {
+            println!("✓ No stale references found.");
+        } else {
+            println!(
+                "Stale references ({total} total{})\n",
+                if total > args.limit {
+                    format!(", showing first {}", args.limit)
+                } else {
+                    String::new()
+                }
+            );
+            for r in report.stale_refs.iter().take(args.limit) {
+                println!(
+                    "  {}:{} — `{}` (section: {})",
+                    r.doc_file, r.line, r.reference_name, r.doc_section
+                );
+            }
+            println!();
+        }
+    }
+
+    if !args.no_undocumented {
+        let total = report.undocumented_exports.len();
+        if total == 0 {
+            println!("✓ All exported symbols have documentation coverage.");
+        } else {
+            println!(
+                "Undocumented exports ({total} total{})\n",
+                if total > args.limit {
+                    format!(", showing first {}", args.limit)
+                } else {
+                    String::new()
+                }
+            );
+            for u in report.undocumented_exports.iter().take(args.limit) {
+                println!(
+                    "  {} {} — {} line {}",
+                    u.kind, u.name, u.file_path, u.start_line
+                );
+            }
+        }
     }
 }
 
@@ -1615,7 +1843,10 @@ const SPINNER_TICK_MS: u64 = 80;
 /// Build a styled `ProgressBar` that animates a braille spinner while showing a
 /// counter and message. When stdout is not a TTY the bar falls back to a static
 /// line that still updates on `set_message`.
-#[allow(clippy::expect_used)] // templates are compile-time constants we control
+#[expect(
+    clippy::expect_used,
+    reason = "templates are compile-time constants we control"
+)]
 fn spinner_bar(len: u64, template: &str) -> ProgressBar {
     let pb = ProgressBar::new(len);
     pb.set_style(
@@ -1628,7 +1859,10 @@ fn spinner_bar(len: u64, template: &str) -> ProgressBar {
 }
 
 /// Spinner for indeterminate operations (no known total, e.g. model download).
-#[allow(clippy::expect_used)] // template is a compile-time constant we control
+#[expect(
+    clippy::expect_used,
+    reason = "template is a compile-time constant we control"
+)]
 fn spinner_indefinite(message: &'static str) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
     pb.set_style(
@@ -1778,7 +2012,7 @@ mod tests {
     #[test]
     fn model_state_absent_when_no_files() -> TestResult {
         let temp_dir = tempfile::TempDir::new()?;
-        let state = doctor::compute_model_state(temp_dir.path());
+        let state = doctor::compute_model_state(temp_dir.path(), vectors::DEFAULT_MODEL);
         assert_eq!(state, doctor::ModelState::Absent);
         Ok(())
     }
@@ -1787,7 +2021,7 @@ mod tests {
     fn model_state_present_picks_first_preferred_variant() -> TestResult {
         let temp_dir = tempfile::TempDir::new()?;
         std::fs::write(temp_dir.path().join("model_int8.onnx"), vec![0u8; 42])?;
-        let state = doctor::compute_model_state(temp_dir.path());
+        let state = doctor::compute_model_state(temp_dir.path(), vectors::DEFAULT_MODEL);
         assert_eq!(
             state,
             doctor::ModelState::Present {
@@ -1809,7 +2043,7 @@ mod tests {
         let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom_dir.display());
         std::fs::write(coraline_dir.join("config.toml"), config)?;
 
-        let resolved = doctor::resolve_status_model_dir(root);
+        let (_, resolved) = doctor::resolve_status_model(root);
         assert_eq!(resolved, custom_dir);
         Ok(())
     }

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -1028,6 +1028,22 @@ fn run_status(args: StatusArgs) {
     println!("Config:  {}", cfg_path.display());
     println!("Database: {} ({} bytes)", db_path.display(), db_size);
 
+    let model_dir = resolve_status_model_dir(&project_root);
+    match compute_model_state(&model_dir) {
+        ModelState::Present {
+            ref name,
+            size_bytes,
+        } => {
+            let size_mb = size_bytes / 1_000_000;
+            println!("Embeddings: {name} ({size_mb} MB)");
+        }
+        ModelState::Absent => {
+            println!("Embeddings: not present");
+            println!("            Run `coraline model download` to enable semantic search.");
+        }
+    }
+    println!("Model dir:  {}", model_dir.display());
+
     let hooks = GitHooksManager::new(&project_root);
     if hooks.is_git_repository() {
         if hooks.is_hook_installed() {
@@ -1038,6 +1054,39 @@ fn run_status(args: StatusArgs) {
     } else {
         println!("Git hooks: not a git repository");
     }
+}
+
+/// Resolve the embedding-model directory for the given project, honouring
+/// `vectors.model_dir` in `config.toml` when set, falling back to the global
+/// default (`~/.config/coraline/models/nomic-embed-text-v1.5/`).
+fn resolve_status_model_dir(project_root: &Path) -> PathBuf {
+    let cfg = config::load_toml_config(project_root).unwrap_or_default();
+    cfg.vectors
+        .model_dir
+        .map_or_else(|| vectors::default_model_dir(project_root), PathBuf::from)
+}
+
+/// Pure lookup of which (if any) model variant is present on disk.
+fn compute_model_state(model_dir: &Path) -> ModelState {
+    for name in vectors::MODEL_PREFERENCE_ORDER {
+        let p = model_dir.join(name);
+        if let Ok(meta) = std::fs::metadata(&p) {
+            return ModelState::Present {
+                name: (*name).to_string(),
+                size_bytes: meta.len(),
+            };
+        }
+    }
+    ModelState::Absent
+}
+
+/// Embedding-model state, as surfaced by `coraline status`.
+#[derive(Debug, PartialEq, Eq)]
+enum ModelState {
+    /// At least one variant in `MODEL_PREFERENCE_ORDER` is present.
+    Present { name: String, size_bytes: u64 },
+    /// No model file exists in the directory.
+    Absent,
 }
 
 fn run_query(args: QueryArgs) {
@@ -1691,6 +1740,61 @@ mod tests {
         std::fs::write(coraline_dir.join("config.toml"), "")?;
 
         assert!(is_initialized(root));
+        Ok(())
+    }
+
+    #[test]
+    fn model_state_absent_when_no_files() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let state = compute_model_state(temp_dir.path());
+        assert_eq!(state, ModelState::Absent);
+        Ok(())
+    }
+
+    #[test]
+    fn model_state_present_picks_first_preferred_variant() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        std::fs::write(temp_dir.path().join("model_int8.onnx"), vec![0u8; 42])?;
+        let state = compute_model_state(temp_dir.path());
+        assert_eq!(
+            state,
+            ModelState::Present {
+                name: "model_int8.onnx".to_string(),
+                size_bytes: 42,
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn model_state_present_records_actual_size() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let bytes = vec![0u8; 1_500_000];
+        std::fs::write(temp_dir.path().join("model_int8.onnx"), &bytes)?;
+        let state = compute_model_state(temp_dir.path());
+        assert_eq!(
+            state,
+            ModelState::Present {
+                name: "model_int8.onnx".to_string(),
+                size_bytes: 1_500_000,
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn status_respects_model_dir_override() -> TestResult {
+        let temp_dir = tempfile::TempDir::new()?;
+        let root = temp_dir.path();
+        let coraline_dir = root.join(".coraline");
+        std::fs::create_dir_all(&coraline_dir)?;
+        let custom_dir = root.join("custom-models");
+        std::fs::create_dir_all(&custom_dir)?;
+        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom_dir.display());
+        std::fs::write(coraline_dir.join("config.toml"), config)?;
+
+        let resolved = resolve_status_model_dir(root);
+        assert_eq!(resolved, custom_dir);
         Ok(())
     }
 }

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -1171,22 +1171,25 @@ fn run_status(args: StatusArgs) {
     println!("Config:  {}", cfg_path.display());
     println!("Database: {} ({} bytes)", db_path.display(), db_size);
 
-    let (model_name, model_dir) = doctor::resolve_status_model(&project_root);
-    match doctor::compute_model_state(&model_dir, &model_name) {
-        doctor::ModelState::Present {
-            ref name,
-            size_bytes,
-        } => {
-            let size_mb = size_bytes / 1_000_000;
-            println!("Embeddings: {name} ({size_mb} MB)");
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    {
+        let (model_name, model_dir) = doctor::resolve_status_model(&project_root);
+        match doctor::compute_model_state(&model_dir, &model_name) {
+            doctor::ModelState::Present {
+                ref name,
+                size_bytes,
+            } => {
+                let size_mb = size_bytes / 1_000_000;
+                println!("Embeddings: {name} ({size_mb} MB)");
+            }
+            doctor::ModelState::Absent => {
+                println!("Embeddings: not present");
+                println!("            Run `coraline model download` to enable semantic search.");
+            }
         }
-        doctor::ModelState::Absent => {
-            println!("Embeddings: not present");
-            println!("            Run `coraline model download` to enable semantic search.");
-        }
+        println!("Model:      {model_name}");
+        println!("Model dir:  {}", model_dir.display());
     }
-    println!("Model:      {model_name}");
-    println!("Model dir:  {}", model_dir.display());
 
     let hooks = GitHooksManager::new(&project_root);
     if hooks.is_git_repository() {
@@ -2009,43 +2012,48 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn model_state_absent_when_no_files() -> TestResult {
-        let temp_dir = tempfile::TempDir::new()?;
-        let state = doctor::compute_model_state(temp_dir.path(), vectors::DEFAULT_MODEL);
-        assert_eq!(state, doctor::ModelState::Absent);
-        Ok(())
-    }
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    mod embeddings_tests {
+        use super::*;
 
-    #[test]
-    fn model_state_present_picks_first_preferred_variant() -> TestResult {
-        let temp_dir = tempfile::TempDir::new()?;
-        std::fs::write(temp_dir.path().join("model_int8.onnx"), vec![0u8; 42])?;
-        let state = doctor::compute_model_state(temp_dir.path(), vectors::DEFAULT_MODEL);
-        assert_eq!(
-            state,
-            doctor::ModelState::Present {
-                name: "model_int8.onnx".to_string(),
-                size_bytes: 42,
-            }
-        );
-        Ok(())
-    }
+        #[test]
+        fn model_state_absent_when_no_files() -> TestResult {
+            let temp_dir = tempfile::TempDir::new()?;
+            let state = doctor::compute_model_state(temp_dir.path(), vectors::DEFAULT_MODEL);
+            assert_eq!(state, doctor::ModelState::Absent);
+            Ok(())
+        }
 
-    #[test]
-    fn status_respects_model_dir_override() -> TestResult {
-        let temp_dir = tempfile::TempDir::new()?;
-        let root = temp_dir.path();
-        let coraline_dir = root.join(".coraline");
-        std::fs::create_dir_all(&coraline_dir)?;
-        let custom_dir = root.join("custom-models");
-        std::fs::create_dir_all(&custom_dir)?;
-        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom_dir.display());
-        std::fs::write(coraline_dir.join("config.toml"), config)?;
+        #[test]
+        fn model_state_present_picks_first_preferred_variant() -> TestResult {
+            let temp_dir = tempfile::TempDir::new()?;
+            std::fs::write(temp_dir.path().join("model_int8.onnx"), vec![0u8; 42])?;
+            let state = doctor::compute_model_state(temp_dir.path(), vectors::DEFAULT_MODEL);
+            assert_eq!(
+                state,
+                doctor::ModelState::Present {
+                    name: "model_int8.onnx".to_string(),
+                    size_bytes: 42,
+                }
+            );
+            Ok(())
+        }
 
-        let (_, resolved) = doctor::resolve_status_model(root);
-        assert_eq!(resolved, custom_dir);
-        Ok(())
+        #[test]
+        fn status_respects_model_dir_override() -> TestResult {
+            let temp_dir = tempfile::TempDir::new()?;
+            let root = temp_dir.path();
+            let coraline_dir = root.join(".coraline");
+            std::fs::create_dir_all(&coraline_dir)?;
+            let custom_dir = root.join("custom-models");
+            std::fs::create_dir_all(&custom_dir)?;
+            let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom_dir.display());
+            std::fs::write(coraline_dir.join("config.toml"), config)?;
+
+            let (_, resolved) = doctor::resolve_status_model(root);
+            assert_eq!(resolved, custom_dir);
+            Ok(())
+        }
     }
 }
 

--- a/crates/coraline/src/bin/coraline.rs
+++ b/crates/coraline/src/bin/coraline.rs
@@ -62,6 +62,19 @@ struct InitArgs {
         help = "Overwrite existing .coraline directory without prompting"
     )]
     force: bool,
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    /// Download the embedding model during init (skips the TTY prompt).
+    #[arg(long = "embed")]
+    embed: bool,
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    /// Skip the embedding model entirely (no prompt, no download).
+    /// Conflicts with `--embed`.
+    #[arg(long = "no-embed", conflicts_with = "embed")]
+    no_embed: bool,
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    /// Non-interactive mode. Auto-accepts the model download prompt.
+    #[arg(short = 'y', long = "yes")]
+    yes: bool,
 }
 
 #[derive(Debug, Args)]
@@ -675,7 +688,7 @@ fn run_init(args: InitArgs) {
                 project_root.display()
             );
             #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-            maybe_prompt_model_download(&project_root);
+            init_model::handle_model_decision(&project_root, args.embed, args.no_embed, args.yes);
             run_index(IndexArgs {
                 path: Some(project_root),
                 force: false,
@@ -753,7 +766,7 @@ fn run_init(args: InitArgs) {
     }
 
     #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-    maybe_prompt_model_download(&project_root);
+    init_model::handle_model_decision(&project_root, args.embed, args.no_embed, args.yes);
 
     if args.index {
         run_index(IndexArgs {
@@ -764,52 +777,140 @@ fn run_init(args: InitArgs) {
     }
 }
 
-/// After a fresh `init`, offer to download the embedding model when stdin is a
-/// terminal.  If the user declines (or is non-interactive), we print a hint and
-/// continue — all non-embedding tools remain fully functional.
 #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-fn maybe_prompt_model_download(project_root: &Path) {
-    use std::io::Write as _;
+mod init_model {
+    use super::{Path, PathBuf, config, vectors};
 
-    let cfg = config::load_toml_config(project_root).unwrap_or_default();
-    let model_dir = cfg
-        .vectors
-        .model_dir
-        .map_or_else(|| vectors::default_model_dir(project_root), PathBuf::from);
-
-    // Nothing to do if any model variant is already present.
-    if vectors::MODEL_PREFERENCE_ORDER
-        .iter()
-        .any(|name| model_dir.join(name).exists())
-    {
-        return;
+    /// Inputs to the embedding-model decision.
+    ///
+    /// Bundled in a struct so the decision function takes a single argument
+    /// (and to keep `clippy::fn_params_excessive_bools` happy).
+    /// `struct_excessive_bools` is allow-by-default in this project.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub struct ModelInputs {
+        pub model_present: bool,
+        pub no_embed: bool,
+        pub embed: bool,
+        pub yes: bool,
+        pub is_tty: bool,
     }
 
-    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-        eprintln!(
-            "Tip: run `coraline model download` then `coraline embed` to enable semantic search."
-        );
-        return;
+    /// After a fresh `init`, decide what to do about the embedding model and
+    /// execute the chosen action. Behaviour is sum of the `InitArgs` flags
+    /// (`--embed`, `--no-embed`, `--yes`) plus the TTY state and whether the
+    /// model is already on disk. All non-embedding tools remain fully
+    /// functional regardless of the chosen action.
+    pub fn handle_model_decision(project_root: &Path, embed: bool, no_embed: bool, yes: bool) {
+        let model_dir = resolve_model_dir(project_root);
+        let model_present = vectors::MODEL_PREFERENCE_ORDER
+            .iter()
+            .any(|name| model_dir.join(name).exists());
+        let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+        let inputs = ModelInputs {
+            model_present,
+            no_embed,
+            embed,
+            yes,
+            is_tty,
+        };
+        let action = decide_model_action(inputs);
+        execute_model_action(project_root, &action);
     }
 
-    eprint!("Download embedding model for semantic search? (~137 MB) [Y/n] ");
-    let _ = std::io::stderr().flush();
-    let mut input = String::new();
-    if std::io::stdin().read_line(&mut input).is_err() {
-        return;
+    /// What action to take regarding the embedding model after `init`.
+    ///
+    /// The decision is pure: it takes the inputs and returns the action. The
+    /// IO/execution side is in [`execute_model_action`].
+    #[derive(Debug, PartialEq, Eq)]
+    pub enum ModelAction {
+        /// Model already present; nothing to do.
+        NoOp,
+        /// User opted out (`--no-embed` or declined the TTY prompt).
+        Skip,
+        /// Download the model now.
+        Download,
+        /// Interactive prompt needed.
+        Prompt,
+        /// Non-interactive, no explicit decision; print a hint.
+        Hint,
     }
-    let answer = input.trim();
-    if answer.is_empty() || answer.eq_ignore_ascii_case("y") {
+
+    /// Pure decision function for the post-init model action.
+    ///
+    /// Precedence:
+    /// 1. Model present → `NoOp`
+    /// 2. `--no-embed` → `Skip`
+    /// 3. `--embed` or `--yes` → `Download`
+    /// 4. TTY → `Prompt`
+    /// 5. Otherwise → `Hint`
+    pub const fn decide_model_action(inputs: ModelInputs) -> ModelAction {
+        if inputs.model_present {
+            return ModelAction::NoOp;
+        }
+        if inputs.no_embed {
+            return ModelAction::Skip;
+        }
+        if inputs.embed || inputs.yes {
+            return ModelAction::Download;
+        }
+        if inputs.is_tty {
+            return ModelAction::Prompt;
+        }
+        ModelAction::Hint
+    }
+
+    pub fn resolve_model_dir(project_root: &Path) -> PathBuf {
+        let cfg = config::load_toml_config(project_root).unwrap_or_default();
+        cfg.vectors
+            .model_dir
+            .map_or_else(|| vectors::default_model_dir(project_root), PathBuf::from)
+    }
+
+    pub fn execute_model_action(project_root: &Path, action: &ModelAction) {
+        use std::io::Write as _;
+        let model_dir = resolve_model_dir(project_root);
+
+        match action {
+            ModelAction::NoOp => {}
+            ModelAction::Skip => {
+                println!("Skipped. Run `coraline model download` later to enable semantic search.");
+            }
+            ModelAction::Download => {
+                download_model_and_report(&model_dir);
+            }
+            ModelAction::Prompt => {
+                eprint!("Download embedding model for semantic search? (~137 MB) [Y/n] ");
+                let _ = std::io::stderr().flush();
+                let mut input = String::new();
+                if std::io::stdin().read_line(&mut input).is_err() {
+                    return;
+                }
+                let answer = input.trim();
+                if answer.is_empty() || answer.eq_ignore_ascii_case("y") {
+                    download_model_and_report(&model_dir);
+                } else {
+                    println!(
+                        "Skipped. Run `coraline model download` later to enable semantic search."
+                    );
+                }
+            }
+            ModelAction::Hint => {
+                eprintln!(
+                    "Tip: run `coraline model download` then `coraline embed` to enable semantic search."
+                );
+            }
+        }
+    }
+
+    fn download_model_and_report(model_dir: &Path) {
         println!("Downloading model into {} ...", model_dir.display());
-        match vectors::download_model(&model_dir, "model_int8.onnx", true, false) {
+        match vectors::download_model(model_dir, "model_int8.onnx", true, false) {
             Ok(()) => println!("Done. Run `coraline embed` to generate embeddings."),
             Err(e) => {
                 eprintln!("Model download failed: {e}");
                 eprintln!("You can retry later with: coraline model download");
             }
         }
-    } else {
-        println!("Skipped. Run `coraline model download` later to enable semantic search.");
     }
 }
 
@@ -1591,5 +1692,116 @@ mod tests {
 
         assert!(is_initialized(root));
         Ok(())
+    }
+}
+
+#[cfg(all(test, any(feature = "embeddings", feature = "embeddings-dynamic")))]
+mod init_flag_tests {
+    use super::init_model::*;
+
+    #[test]
+    fn model_present_is_noop() {
+        let m = ModelInputs {
+            model_present: true,
+            is_tty: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::NoOp);
+        let m = ModelInputs {
+            model_present: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::NoOp);
+    }
+
+    #[test]
+    fn model_present_short_circuits_all_flags() {
+        // Even with --embed and --yes, model present is NoOp.
+        let m = ModelInputs {
+            model_present: true,
+            embed: true,
+            yes: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::NoOp);
+        // --no-embed is irrelevant when model is present.
+        let m = ModelInputs {
+            model_present: true,
+            no_embed: true,
+            is_tty: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::NoOp);
+    }
+
+    #[test]
+    fn no_embed_skips() {
+        let m = ModelInputs {
+            no_embed: true,
+            is_tty: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Skip);
+        let m = ModelInputs {
+            no_embed: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Skip);
+    }
+
+    #[test]
+    fn embed_downloads_regardless_of_tty() {
+        let m = ModelInputs {
+            embed: true,
+            is_tty: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Download);
+        let m = ModelInputs {
+            embed: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Download);
+    }
+
+    #[test]
+    fn yes_auto_downloads() {
+        let m = ModelInputs {
+            yes: true,
+            is_tty: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Download);
+        let m = ModelInputs {
+            yes: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Download);
+    }
+
+    #[test]
+    fn no_embed_wins_over_yes() {
+        let m = ModelInputs {
+            no_embed: true,
+            yes: true,
+            is_tty: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Skip);
+    }
+
+    #[test]
+    fn no_flags_tty_prompts() {
+        let m = ModelInputs {
+            is_tty: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_model_action(m), ModelAction::Prompt);
+    }
+
+    #[test]
+    fn no_flags_non_tty_hints() {
+        let m = ModelInputs::default();
+        assert_eq!(decide_model_action(m), ModelAction::Hint);
     }
 }

--- a/crates/coraline/src/config.rs
+++ b/crates/coraline/src/config.rs
@@ -483,6 +483,7 @@ impl Default for IndexingConfig {
 /// Stored at `.coraline/config.toml`.  All sections are optional with
 /// sensible defaults so that an empty file is perfectly valid.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct CoralineConfig {
     pub indexing: IndexingConfig,
     pub context: ContextConfig,

--- a/crates/coraline/src/config.rs
+++ b/crates/coraline/src/config.rs
@@ -744,20 +744,35 @@ debounce_ms              = 500
 auto_sync_interval_secs  = 120
 
 [vectors]
-# Full vector search requires an ONNX model.
-# Download any variant from huggingface.co/nomic-ai/nomic-embed-text-v1.5
-# (also copy tokenizer.json) into the directory below:
-#   model_int8.onnx      137 MB  — int8 quantized (recommended)
-#   model_quantized.onnx 137 MB  — same as int8
-#   model_uint8.onnx     137 MB  — uint8 quantized
-#   model_q4f16.onnx     111 MB  — smallest (Q4 + fp16)
-#   model_q4.onnx        165 MB  — Q4 quantized
-#   model_fp16.onnx      274 MB  — fp16
-#   model.onnx           547 MB  — full f32
-# Coraline auto-selects the best available file; set model_file to override.
-# Then run: coraline embed
+# Full vector search requires an ONNX model. Run `coraline model list` to see
+# every supported model, then `coraline model download` (optionally with
+# `--model <name>`) to fetch it into the shared model directory.
+#
+# Supported models (set `model` to one of these):
+#   nomic-embed-text-v1.5        768-dim  General-purpose English text (default).
+#     model_int8.onnx      137 MB  — int8 quantized (recommended)
+#     model_quantized.onnx 137 MB  — same as int8
+#     model_uint8.onnx     137 MB  — uint8 quantized
+#     model_q4f16.onnx     111 MB  — smallest (Q4 + fp16)
+#     model_q4.onnx        165 MB  — Q4 quantized
+#     model_fp16.onnx      274 MB  — fp16
+#     model.onnx           547 MB  — full f32
+#   jina-embeddings-v2-base-code 768-dim  Code-specialised (opt-in).
+#     model_quantized.onnx 162 MB  — int8 quantized (recommended)
+#     model_fp16.onnx      321 MB  — fp16
+#     model.onnx           642 MB  — full f32
+#
+# Coraline auto-selects the best available file for the configured `model`;
+# set model_file to pin a specific variant. Switching `model` on a project
+# with existing embeddings requires re-running `coraline embed` to
+# repopulate — see the `vectors` module docs for details.
+#
+# `model` is commented out by default so this project inherits whatever
+# model your global ~/.config/coraline/config.toml sets (or the built-in
+# default, nomic-embed-text-v1.5, if you haven't set one) — uncomment to
+# pin this project to a specific model regardless of your global default.
 enabled    = false
-model      = "nomic-embed-text-v1.5"
+# model      = "nomic-embed-text-v1.5"                    # or "jina-embeddings-v2-base-code"
 dimension  = 768
 batch_size = 32
 max_seq_len = 512

--- a/crates/coraline/src/db.rs
+++ b/crates/coraline/src/db.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use tracing::{debug, warn};
 
 use crate::types::{
@@ -288,7 +288,6 @@ pub fn insert_unresolved_refs(
 /// This is more efficient than the three separate `insert_nodes` /
 /// `insert_edges` / `insert_unresolved_refs` calls because it incurs only
 /// one transaction commit instead of three.
-#[allow(clippy::too_many_lines)]
 pub fn store_file_batch(
     conn: &mut Connection,
     file_record: &FileRecord,
@@ -298,107 +297,130 @@ pub fn store_file_batch(
 ) -> std::io::Result<()> {
     let tx = conn.transaction().map_err(io_other)?;
 
-    // Nodes
-    if !nodes.is_empty() {
-        let mut stmt = tx
-            .prepare(
-                "INSERT INTO nodes (
-                    id, kind, name, qualified_name, file_path, language,
-                    start_line, end_line, start_column, end_column,
-                    docstring, signature, visibility,
-                    is_exported, is_async, is_static, is_abstract,
-                    decorators, type_parameters, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            )
-            .map_err(io_other)?;
-        for node in nodes {
-            let decorators = node
-                .decorators
-                .as_ref()
-                .map(|v| serde_json::to_string(v).unwrap_or_default());
-            let type_parameters = node
-                .type_parameters
-                .as_ref()
-                .map(|v| serde_json::to_string(v).unwrap_or_default());
-            let visibility = node.visibility.map(visibility_to_string);
-            stmt.execute(params![
-                node.id,
-                kind_to_string(node.kind),
-                node.name,
-                node.qualified_name,
-                node.file_path,
-                language_to_string(node.language),
-                node.start_line,
-                node.end_line,
-                node.start_column,
-                node.end_column,
-                node.docstring,
-                node.signature,
-                visibility,
-                i32::from(node.is_exported),
-                i32::from(node.is_async),
-                i32::from(node.is_static),
-                i32::from(node.is_abstract),
-                decorators,
-                type_parameters,
-                node.updated_at,
-            ])
-            .map_err(io_other)?;
-        }
-    }
+    insert_node_batch(&tx, nodes)?;
+    insert_edge_batch(&tx, edges)?;
+    insert_unresolved_ref_batch(&tx, unresolved_refs)?;
+    upsert_file_record(&tx, file_record)?;
 
-    // Edges
-    if !edges.is_empty() {
-        let mut stmt = tx
-            .prepare(
-                "INSERT INTO edges (source, target, kind, metadata, line, col)
-                 VALUES (?, ?, ?, ?, ?, ?)",
-            )
-            .map_err(io_other)?;
-        for edge in edges {
-            let metadata = edge
-                .metadata
-                .as_ref()
-                .map(|v| serde_json::to_string(v).unwrap_or_default());
-            stmt.execute(params![
-                edge.source,
-                edge.target,
-                edge_kind_to_string(edge.kind),
-                metadata,
-                edge.line,
-                edge.column,
-            ])
-            .map_err(io_other)?;
-        }
-    }
+    tx.commit().map_err(|err| {
+        warn!(file = %file_record.path, error = %err, "store_file_batch commit failed");
+        io_other(err)
+    })
+}
 
-    // Unresolved references
-    if !unresolved_refs.is_empty() {
-        let mut stmt = tx
-            .prepare(
-                "INSERT INTO unresolved_refs (
-                    from_node_id, reference_name, reference_kind, line, col, candidates
-                 ) VALUES (?, ?, ?, ?, ?, ?)",
-            )
-            .map_err(io_other)?;
-        for r in unresolved_refs {
-            let candidates = r
-                .candidates
-                .as_ref()
-                .map(|v| serde_json::to_string(v).unwrap_or_default());
-            stmt.execute(params![
-                r.from_node_id,
-                r.reference_name,
-                edge_kind_to_string(r.reference_kind),
-                r.line,
-                r.column,
-                candidates,
-            ])
-            .map_err(io_other)?;
-        }
+fn insert_node_batch(tx: &Transaction, nodes: &[Node]) -> std::io::Result<()> {
+    if nodes.is_empty() {
+        return Ok(());
     }
+    let mut stmt = tx
+        .prepare(
+            "INSERT INTO nodes (
+                id, kind, name, qualified_name, file_path, language,
+                start_line, end_line, start_column, end_column,
+                docstring, signature, visibility,
+                is_exported, is_async, is_static, is_abstract,
+                decorators, type_parameters, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .map_err(io_other)?;
+    for node in nodes {
+        let decorators = node
+            .decorators
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+        let type_parameters = node
+            .type_parameters
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+        let visibility = node.visibility.map(visibility_to_string);
+        stmt.execute(params![
+            node.id,
+            kind_to_string(node.kind),
+            node.name,
+            node.qualified_name,
+            node.file_path,
+            language_to_string(node.language),
+            node.start_line,
+            node.end_line,
+            node.start_column,
+            node.end_column,
+            node.docstring,
+            node.signature,
+            visibility,
+            i32::from(node.is_exported),
+            i32::from(node.is_async),
+            i32::from(node.is_static),
+            i32::from(node.is_abstract),
+            decorators,
+            type_parameters,
+            node.updated_at,
+        ])
+        .map_err(io_other)?;
+    }
+    Ok(())
+}
 
-    // File record (upsert)
+fn insert_edge_batch(tx: &Transaction, edges: &[Edge]) -> std::io::Result<()> {
+    if edges.is_empty() {
+        return Ok(());
+    }
+    let mut stmt = tx
+        .prepare(
+            "INSERT INTO edges (source, target, kind, metadata, line, col)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .map_err(io_other)?;
+    for edge in edges {
+        let metadata = edge
+            .metadata
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+        stmt.execute(params![
+            edge.source,
+            edge.target,
+            edge_kind_to_string(edge.kind),
+            metadata,
+            edge.line,
+            edge.column,
+        ])
+        .map_err(io_other)?;
+    }
+    Ok(())
+}
+
+fn insert_unresolved_ref_batch(
+    tx: &Transaction,
+    unresolved_refs: &[UnresolvedReference],
+) -> std::io::Result<()> {
+    if unresolved_refs.is_empty() {
+        return Ok(());
+    }
+    let mut stmt = tx
+        .prepare(
+            "INSERT INTO unresolved_refs (
+                from_node_id, reference_name, reference_kind, line, col, candidates
+             ) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .map_err(io_other)?;
+    for r in unresolved_refs {
+        let candidates = r
+            .candidates
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+        stmt.execute(params![
+            r.from_node_id,
+            r.reference_name,
+            edge_kind_to_string(r.reference_kind),
+            r.line,
+            r.column,
+            candidates,
+        ])
+        .map_err(io_other)?;
+    }
+    Ok(())
+}
+
+fn upsert_file_record(tx: &Transaction, file_record: &FileRecord) -> std::io::Result<()> {
     let errors = file_record
         .errors
         .as_ref()
@@ -426,11 +448,7 @@ pub fn store_file_batch(
         ],
     )
     .map_err(io_other)?;
-
-    tx.commit().map_err(|err| {
-        warn!(file = %file_record.path, error = %err, "store_file_batch commit failed");
-        io_other(err)
-    })
+    Ok(())
 }
 
 pub fn search_nodes(
@@ -471,7 +489,10 @@ pub fn search_nodes(
         .query_map(rusqlite::params_from_iter(params_vec), |row| {
             // FTS rank is negative, convert to positive score (higher = better)
             let rank: f64 = row.get(20)?;
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "f64 -> f32 score narrowing; no checked TryFrom<f64> for f32 in std"
+            )]
             let score = (-rank) as f32;
             Ok(SearchResult {
                 node: row_to_node(row)?,
@@ -750,8 +771,12 @@ pub fn get_all_nodes(conn: &Connection) -> std::io::Result<Vec<Node>> {
     Ok(results)
 }
 
-/// Return nodes that have no corresponding row in the `vectors` table.
-pub fn get_unembedded_nodes(conn: &Connection) -> std::io::Result<Vec<Node>> {
+/// Return nodes that have no row in the `vectors` table for `model`.
+///
+/// A node with an embedding from a *different* (previously configured)
+/// model still counts as unembedded here, so coverage reporting stays
+/// honest across model switches.
+pub fn get_unembedded_nodes(conn: &Connection, model: &str) -> std::io::Result<Vec<Node>> {
     let mut stmt = conn
         .prepare(
             "SELECT n.id, n.kind, n.name, n.qualified_name, n.file_path, n.language,
@@ -760,13 +785,15 @@ pub fn get_unembedded_nodes(conn: &Connection) -> std::io::Result<Vec<Node>> {
                     n.is_exported, n.is_async, n.is_static, n.is_abstract,
                     n.decorators, n.type_parameters, n.updated_at
              FROM nodes n
-             LEFT JOIN vectors v ON n.id = v.node_id
+             LEFT JOIN vectors v ON n.id = v.node_id AND v.model = ?1
              WHERE v.node_id IS NULL
              ORDER BY n.file_path ASC, n.start_line ASC",
         )
         .map_err(io_other)?;
 
-    let rows = stmt.query_map([], row_to_node).map_err(io_other)?;
+    let rows = stmt
+        .query_map(params![model], row_to_node)
+        .map_err(io_other)?;
     let mut results = Vec::new();
     for row in rows {
         results.push(row.map_err(io_other)?);
@@ -1077,8 +1104,65 @@ pub fn get_doc_coverage_stats(conn: &Connection) -> std::io::Result<(usize, usiz
 
 #[cfg(test)]
 mod tests {
-    use super::build_fts_query;
+    #![expect(
+        clippy::expect_used,
+        reason = "test assertions: panicking on setup failure is the correct behavior"
+    )]
+    use super::{SCHEMA_SQL, build_fts_query, get_unembedded_nodes};
     use rusqlite::Connection;
+
+    fn seed_node(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO nodes (id, kind, name, qualified_name, file_path, language,
+                start_line, end_line, start_column, end_column, updated_at)
+             VALUES (?1, 'function', ?1, ?1, 'src/lib.rs', 'rust', 1, 1, 0, 0, 0)",
+            [id],
+        )
+        .expect("insert node");
+    }
+
+    fn seed_vector(conn: &Connection, node_id: &str, model: &str) {
+        conn.execute(
+            "INSERT INTO vectors (node_id, embedding, model, created_at)
+             VALUES (?1, x'00', ?2, 0)",
+            [node_id, model],
+        )
+        .expect("insert vector");
+    }
+
+    #[test]
+    fn get_unembedded_nodes_excludes_rows_from_other_models() {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch(SCHEMA_SQL).expect("apply schema");
+
+        seed_node(&conn, "node_a");
+        seed_node(&conn, "node_b");
+        // node_a has an embedding, but from a *different* model than the one
+        // we're checking coverage for — it must still count as unembedded.
+        seed_vector(&conn, "node_a", "other-model");
+
+        let unembedded =
+            get_unembedded_nodes(&conn, "nomic-embed-text-v1.5").expect("query unembedded");
+        let ids: Vec<&str> = unembedded.iter().map(|n| n.id.as_str()).collect();
+        assert!(ids.contains(&"node_a"));
+        assert!(ids.contains(&"node_b"));
+        assert_eq!(ids.len(), 2);
+    }
+
+    #[test]
+    fn get_unembedded_nodes_excludes_rows_from_matching_model() {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch(SCHEMA_SQL).expect("apply schema");
+
+        seed_node(&conn, "node_a");
+        seed_node(&conn, "node_b");
+        seed_vector(&conn, "node_a", "nomic-embed-text-v1.5");
+
+        let unembedded =
+            get_unembedded_nodes(&conn, "nomic-embed-text-v1.5").expect("query unembedded");
+        let ids: Vec<&str> = unembedded.iter().map(|n| n.id.as_str()).collect();
+        assert_eq!(ids, vec!["node_b"]);
+    }
 
     #[test]
     fn build_fts_query_quotes_slash_terms() {

--- a/crates/coraline/src/doctor.rs
+++ b/crates/coraline/src/doctor.rs
@@ -148,11 +148,11 @@ pub fn check_hooks(project_root: &Path) -> Probe {
     }
 }
 
-/// Check that at least one model variant from `MODEL_PREFERENCE_ORDER` is
-/// present on disk.
+/// Check that at least one model variant of the configured model is present
+/// on disk.
 pub fn check_model_presence(project_root: &Path) -> Probe {
-    let model_dir = resolve_status_model_dir(project_root);
-    match compute_model_state(&model_dir) {
+    let (model_name, model_dir) = resolve_status_model(project_root);
+    match compute_model_state(&model_dir, &model_name) {
         ModelState::Present { name, size_bytes } => {
             let size_mb = size_bytes / 1_000_000;
             Probe {
@@ -165,7 +165,10 @@ pub fn check_model_presence(project_root: &Path) -> Probe {
         ModelState::Absent => Probe {
             name: "model file",
             ok: false,
-            detail: "no model file in MODEL_PREFERENCE_ORDER".to_string(),
+            detail: format!(
+                "no model file for '{model_name}' in {}",
+                model_dir.display()
+            ),
             fix: Some("Run `coraline model download`.".to_string()),
         },
     }
@@ -257,7 +260,8 @@ pub fn check_embed_coverage(project_root: &Path) -> Probe {
             };
         }
     };
-    let unembedded = match db::get_unembedded_nodes(&conn) {
+    let (model_name, _) = resolve_status_model(project_root);
+    let unembedded = match db::get_unembedded_nodes(&conn, &model_name) {
         Ok(nodes) => nodes.len(),
         Err(e) => {
             return Probe {
@@ -287,15 +291,18 @@ pub fn check_embed_coverage(project_root: &Path) -> Probe {
 /// Embedding-model state, as surfaced by `coraline status`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ModelState {
-    /// At least one variant in `MODEL_PREFERENCE_ORDER` is present.
+    /// At least one variant in the model's preference order is present.
     Present { name: String, size_bytes: u64 },
     /// No model file exists in the directory.
     Absent,
 }
 
-/// Pure lookup of which (if any) model variant is present on disk.
-pub fn compute_model_state(model_dir: &Path) -> ModelState {
-    for name in vectors::MODEL_PREFERENCE_ORDER {
+/// Pure lookup of which (if any) variant of `model_name` is present on disk.
+pub fn compute_model_state(model_dir: &Path, model_name: &str) -> ModelState {
+    let Ok(spec) = vectors::model_spec(model_name) else {
+        return ModelState::Absent;
+    };
+    for name in spec.preference_order {
         let p = model_dir.join(name);
         if let Ok(meta) = std::fs::metadata(&p) {
             return ModelState::Present {
@@ -307,15 +314,21 @@ pub fn compute_model_state(model_dir: &Path) -> ModelState {
     ModelState::Absent
 }
 
-/// Resolve the embedding-model directory for the given project.
+/// Resolve the configured model name and its on-disk directory for the
+/// given project.
 ///
-/// Honours `vectors.model_dir` in `config.toml` when set; falls back to the
-/// global default (`~/.config/coraline/models/nomic-embed-text-v1.5/`).
-pub fn resolve_status_model_dir(project_root: &Path) -> PathBuf {
+/// Honours `vectors.model` and `vectors.model_dir` in `config.toml`; falls
+/// back to the default model's global directory
+/// (`~/.config/coraline/models/nomic-embed-text-v1.5/`) if config is
+/// missing, unreadable, or names an unknown model.
+pub fn resolve_status_model(project_root: &Path) -> (String, PathBuf) {
     let cfg = config::load_toml_config(project_root).unwrap_or_default();
-    cfg.vectors
-        .model_dir
-        .map_or_else(|| vectors::default_model_dir(project_root), PathBuf::from)
+    vectors::resolve_model_dir(&cfg.vectors).unwrap_or_else(|_| {
+        (
+            vectors::DEFAULT_MODEL.to_string(),
+            vectors::global_model_dir(),
+        )
+    })
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -413,7 +426,15 @@ mod tests {
         let models_dir = root.path().join("models");
         fs::create_dir_all(&models_dir)?;
         fs::write(models_dir.join("model_int8.onnx"), vec![0u8; 1_000_000])?;
-        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", models_dir.display());
+        // Pin `model` explicitly (not just `model_dir`) so this test is
+        // deterministic regardless of the developer's real global
+        // ~/.config/coraline/config.toml, which may set `vectors.model` to
+        // a different supported model (e.g. jina-embeddings-v2-base-code)
+        // with its own, non-overlapping variant filenames.
+        let config = format!(
+            "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = \"{}\"\n",
+            models_dir.display()
+        );
         fs::write(coraline_dir.join("config.toml"), config)?;
         let probe = check_model_presence(root.path());
         assert_eq!(probe.name, "model file");
@@ -424,7 +445,7 @@ mod tests {
     #[test]
     fn model_state_absent_when_empty_dir() -> TestResult {
         let root = empty_temp()?;
-        let state = compute_model_state(root.path());
+        let state = compute_model_state(root.path(), vectors::DEFAULT_MODEL);
         assert_eq!(state, ModelState::Absent);
         Ok(())
     }
@@ -433,7 +454,7 @@ mod tests {
     fn model_state_present_picks_first_preferred() -> TestResult {
         let root = empty_temp()?;
         fs::write(root.path().join("model_int8.onnx"), vec![0u8; 42])?;
-        let state = compute_model_state(root.path());
+        let state = compute_model_state(root.path(), vectors::DEFAULT_MODEL);
         assert_eq!(
             state,
             ModelState::Present {
@@ -445,6 +466,15 @@ mod tests {
     }
 
     #[test]
+    fn model_state_absent_for_unknown_model() -> TestResult {
+        let root = empty_temp()?;
+        fs::write(root.path().join("model_int8.onnx"), vec![0u8; 42])?;
+        let state = compute_model_state(root.path(), "not-a-real-model");
+        assert_eq!(state, ModelState::Absent);
+        Ok(())
+    }
+
+    #[test]
     fn resolve_status_returns_a_non_empty_path() -> TestResult {
         // We can't assert a specific default model here because `load_toml_config`
         // merges in the user's global `~/.config/coraline/config.toml`, which
@@ -452,7 +482,7 @@ mod tests {
         // is also not cross-platform (see config.rs). The override path is
         // covered separately; here we just verify the function returns a path.
         let root = empty_temp()?;
-        let resolved = resolve_status_model_dir(root.path());
+        let (_, resolved) = resolve_status_model(root.path());
         assert!(resolved.file_name().is_some());
         Ok(())
     }
@@ -466,8 +496,21 @@ mod tests {
         fs::create_dir_all(&custom)?;
         let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom.display());
         fs::write(coraline_dir.join("config.toml"), config)?;
-        let resolved = resolve_status_model_dir(root.path());
+        let (_, resolved) = resolve_status_model(root.path());
         assert_eq!(resolved, custom);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_status_respects_configured_model() -> TestResult {
+        let root = empty_temp()?;
+        let coraline_dir = root.path().join(".coraline");
+        fs::create_dir_all(&coraline_dir)?;
+        let config = "[vectors]\nmodel = \"jina-embeddings-v2-base-code\"\n";
+        fs::write(coraline_dir.join("config.toml"), config)?;
+        let (model_name, resolved) = resolve_status_model(root.path());
+        assert_eq!(model_name, "jina-embeddings-v2-base-code");
+        assert!(resolved.ends_with("jina-embeddings-v2-base-code"));
         Ok(())
     }
 

--- a/crates/coraline/src/doctor.rs
+++ b/crates/coraline/src/doctor.rs
@@ -429,7 +429,10 @@ mod tests {
             let coraline_dir = root.path().join(".coraline");
             fs::create_dir_all(&coraline_dir)?;
             let models_dir = root.path().join("models");
-            let config = format!("[vectors]\nmodel_dir = \"{}\"\n", models_dir.display());
+            // TOML literal string (single quotes): backslash-separated
+            // Windows paths would be misinterpreted as escape sequences
+            // inside a basic (double-quoted) string.
+            let config = format!("[vectors]\nmodel_dir = '{}'\n", models_dir.display());
             fs::write(coraline_dir.join("config.toml"), config)?;
             let probe = check_model_presence(root.path());
             assert!(!probe.ok);
@@ -454,7 +457,7 @@ mod tests {
             // a different supported model (e.g. jina-embeddings-v2-base-code)
             // with its own, non-overlapping variant filenames.
             let config = format!(
-                "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = \"{}\"\n",
+                "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = '{}'\n",
                 models_dir.display()
             );
             fs::write(coraline_dir.join("config.toml"), config)?;
@@ -516,7 +519,7 @@ mod tests {
             fs::create_dir_all(&coraline_dir)?;
             let custom = root.path().join("custom-models");
             fs::create_dir_all(&custom)?;
-            let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom.display());
+            let config = format!("[vectors]\nmodel_dir = '{}'\n", custom.display());
             fs::write(coraline_dir.join("config.toml"), config)?;
             let (_, resolved) = resolve_status_model(root.path());
             assert_eq!(resolved, custom);

--- a/crates/coraline/src/doctor.rs
+++ b/crates/coraline/src/doctor.rs
@@ -1,0 +1,587 @@
+#![forbid(unsafe_code)]
+
+//! Diagnostic checks for the Coraline installation.
+//!
+//! [`run_all`] builds a [`Report`] of [`Probe`]s covering config, database,
+//! git hooks, and model presence. With `deep = true`, three additional slow
+//! probes are added: ONNX model load, inference, and embedding-coverage count.
+//!
+//! The probe contract is intentionally narrow:
+//!
+//! - `name` — a short stable identifier (used as a JSON key and a human label).
+//! - `ok` — pass/fail.
+//! - `detail` — a one-line human-readable description; the user can read this
+//!   without leaving the terminal.
+//! - `fix` — when `ok` is false, a remediation hint that points at the
+//!   next command the user should run.
+//!
+//! Ordering is stable so the output is deterministic.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::config;
+use crate::db;
+use crate::sync::GitHooksManager;
+use crate::vectors;
+
+/// One diagnostic check.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Probe {
+    /// Short stable identifier (used as JSON key and human label).
+    pub name: &'static str,
+    pub ok: bool,
+    pub detail: String,
+    /// Optional remediation hint. Skipped from JSON when `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<String>,
+}
+
+/// Result of a `doctor` run.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Report {
+    pub probes: Vec<Probe>,
+    /// Shell exit code: 0 if all probes passed, 1 otherwise.
+    pub exit_code: i32,
+}
+
+impl Report {
+    /// Build a `Report` from probes, deriving `exit_code` from probe results.
+    pub fn from_probes(probes: Vec<Probe>) -> Self {
+        let exit_code = i32::from(!probes.iter().all(|p| p.ok));
+        Self { probes, exit_code }
+    }
+}
+
+/// Run all probes. With `deep = true`, include the slow model probes.
+pub fn run_all(project_root: &Path, deep: bool) -> Report {
+    let mut probes = vec![
+        check_config(project_root),
+        check_db(project_root),
+        check_hooks(project_root),
+        check_model_presence(project_root),
+    ];
+    if deep {
+        #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+        {
+            probes.push(check_model_load(project_root));
+            probes.push(check_model_inference(project_root));
+            probes.push(check_embed_coverage(project_root));
+        }
+    }
+    Report::from_probes(probes)
+}
+
+// ─── Cheap probes ────────────────────────────────────────────────────────────
+
+/// Check that the active `config.toml` is present and readable.
+pub fn check_config(project_root: &Path) -> Probe {
+    let cfg_path = config::toml_config_path(project_root);
+    match std::fs::read_to_string(&cfg_path) {
+        Ok(content) => Probe {
+            name: "config",
+            ok: true,
+            detail: format!("{} ({} bytes)", cfg_path.display(), content.len()),
+            fix: None,
+        },
+        Err(e) => Probe {
+            name: "config",
+            ok: false,
+            detail: format!("{} not readable: {}", cfg_path.display(), e),
+            fix: Some("Run `coraline init` to create config.toml.".to_string()),
+        },
+    }
+}
+
+/// Check that the `SQLite` database can be opened and has stats.
+pub fn check_db(project_root: &Path) -> Probe {
+    let db_path = db::database_path(project_root);
+    match db::open_database(project_root) {
+        Ok(conn) => {
+            let detail = match db::get_db_stats(&conn) {
+                Ok(s) => format!(
+                    "{} ({} nodes, {} edges, {} files)",
+                    db_path.display(),
+                    s.node_count,
+                    s.edge_count,
+                    s.file_count
+                ),
+                Err(e) => format!("{} (open ok, stats failed: {e})", db_path.display()),
+            };
+            Probe {
+                name: "database",
+                ok: true,
+                detail,
+                fix: None,
+            }
+        }
+        Err(e) => Probe {
+            name: "database",
+            ok: false,
+            detail: format!("{} not openable: {}", db_path.display(), e),
+            fix: Some("Run `coraline init` to create the database.".to_string()),
+        },
+    }
+}
+
+/// Check that the git post-commit hook is installed (or n/a for non-git repos).
+pub fn check_hooks(project_root: &Path) -> Probe {
+    let hooks = GitHooksManager::new(project_root);
+    let is_git = hooks.is_git_repository();
+    let installed = hooks.is_hook_installed();
+    let (ok, detail) = match (is_git, installed) {
+        (false, _) => (true, "not a git repository".to_string()),
+        (true, true) => (true, "installed".to_string()),
+        (true, false) => (false, "not installed".to_string()),
+    };
+    let fix = if ok {
+        None
+    } else {
+        Some("Run `coraline hooks install`.".to_string())
+    };
+    Probe {
+        name: "git hooks",
+        ok,
+        detail,
+        fix,
+    }
+}
+
+/// Check that at least one model variant from `MODEL_PREFERENCE_ORDER` is
+/// present on disk.
+pub fn check_model_presence(project_root: &Path) -> Probe {
+    let model_dir = resolve_status_model_dir(project_root);
+    match compute_model_state(&model_dir) {
+        ModelState::Present { name, size_bytes } => {
+            let size_mb = size_bytes / 1_000_000;
+            Probe {
+                name: "model file",
+                ok: true,
+                detail: format!("{name} ({size_mb} MB)"),
+                fix: None,
+            }
+        }
+        ModelState::Absent => Probe {
+            name: "model file",
+            ok: false,
+            detail: "no model file in MODEL_PREFERENCE_ORDER".to_string(),
+            fix: Some("Run `coraline model download`.".to_string()),
+        },
+    }
+}
+
+// ─── Deep probes (cfg-gated) ──────────────────────────────────────────────────
+
+/// Try to instantiate the ONNX `VectorManager`. This is the slowest cheap
+/// check (~340 ms cold) because it loads the model into memory.
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+pub fn check_model_load(project_root: &Path) -> Probe {
+    let start = std::time::Instant::now();
+    match vectors::VectorManager::from_project(project_root) {
+        Ok(_) => Probe {
+            name: "model loads",
+            ok: true,
+            detail: format!("loaded in {:?}", start.elapsed()),
+            fix: None,
+        },
+        Err(e) => Probe {
+            name: "model loads",
+            ok: false,
+            detail: format!("load failed: {e}"),
+            fix: Some("Run `coraline model download`.".to_string()),
+        },
+    }
+}
+
+/// Run a single sample embedding through the model to verify the inference
+/// path works end-to-end.
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+pub fn check_model_inference(project_root: &Path) -> Probe {
+    let mut vm = match vectors::VectorManager::from_project(project_root) {
+        Ok(vm) => vm,
+        Err(e) => {
+            return Probe {
+                name: "inference",
+                ok: false,
+                detail: format!("model not loaded: {e}"),
+                fix: None,
+            };
+        }
+    };
+    let sample = "fn add(a: i32, b: i32) -> i32 { a + b }";
+    match vm.embed(sample) {
+        Ok(embedding) if !embedding.is_empty() => Probe {
+            name: "inference",
+            ok: true,
+            detail: format!("{}d embedding returned", embedding.len()),
+            fix: None,
+        },
+        Ok(_) => Probe {
+            name: "inference",
+            ok: false,
+            detail: "empty embedding returned".to_string(),
+            fix: None,
+        },
+        Err(e) => Probe {
+            name: "inference",
+            ok: false,
+            detail: format!("embed failed: {e}"),
+            fix: None,
+        },
+    }
+}
+
+/// Compare node count to embedded-node count (rows in the `vectors` table).
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+pub fn check_embed_coverage(project_root: &Path) -> Probe {
+    let conn = match db::open_database(project_root) {
+        Ok(c) => c,
+        Err(e) => {
+            return Probe {
+                name: "embed coverage",
+                ok: false,
+                detail: format!("db open failed: {e}"),
+                fix: None,
+            };
+        }
+    };
+    let total = match db::get_all_nodes(&conn) {
+        Ok(nodes) => nodes.len(),
+        Err(e) => {
+            return Probe {
+                name: "embed coverage",
+                ok: false,
+                detail: format!("node query failed: {e}"),
+                fix: None,
+            };
+        }
+    };
+    let unembedded = match db::get_unembedded_nodes(&conn) {
+        Ok(nodes) => nodes.len(),
+        Err(e) => {
+            return Probe {
+                name: "embed coverage",
+                ok: false,
+                detail: format!("unembedded-node query failed: {e}"),
+                fix: None,
+            };
+        }
+    };
+    let embedded = total.saturating_sub(unembedded);
+    let ok = total == 0 || embedded == total;
+    Probe {
+        name: "embed coverage",
+        ok,
+        detail: format!("{embedded}/{total} nodes embedded"),
+        fix: if ok {
+            None
+        } else {
+            Some("Run `coraline embed` to fill vectors.".to_string())
+        },
+    }
+}
+
+// ─── Model state helpers (shared with `coraline status`) ─────────────────────
+
+/// Embedding-model state, as surfaced by `coraline status`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ModelState {
+    /// At least one variant in `MODEL_PREFERENCE_ORDER` is present.
+    Present { name: String, size_bytes: u64 },
+    /// No model file exists in the directory.
+    Absent,
+}
+
+/// Pure lookup of which (if any) model variant is present on disk.
+pub fn compute_model_state(model_dir: &Path) -> ModelState {
+    for name in vectors::MODEL_PREFERENCE_ORDER {
+        let p = model_dir.join(name);
+        if let Ok(meta) = std::fs::metadata(&p) {
+            return ModelState::Present {
+                name: (*name).to_string(),
+                size_bytes: meta.len(),
+            };
+        }
+    }
+    ModelState::Absent
+}
+
+/// Resolve the embedding-model directory for the given project.
+///
+/// Honours `vectors.model_dir` in `config.toml` when set; falls back to the
+/// global default (`~/.config/coraline/models/nomic-embed-text-v1.5/`).
+pub fn resolve_status_model_dir(project_root: &Path) -> PathBuf {
+    let cfg = config::load_toml_config(project_root).unwrap_or_default();
+    cfg.vectors
+        .model_dir
+        .map_or_else(|| vectors::default_model_dir(project_root), PathBuf::from)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    fn empty_temp() -> Result<TempDir, Box<dyn std::error::Error>> {
+        Ok(tempfile::TempDir::new()?)
+    }
+
+    #[test]
+    fn config_missing_when_no_init() -> TestResult {
+        let root = empty_temp()?;
+        let probe = check_config(root.path());
+        assert!(!probe.ok);
+        let Some(fix) = probe.fix.as_ref() else {
+            return Err("expected fix on missing config".into());
+        };
+        assert!(fix.contains("init"));
+        Ok(())
+    }
+
+    #[test]
+    fn config_ok_when_present() -> TestResult {
+        let root = empty_temp()?;
+        fs::create_dir_all(root.path().join(".coraline"))?;
+        let cfg_path = root.path().join(".coraline/config.toml");
+        fs::write(&cfg_path, "[vectors]\n")?;
+        let probe = check_config(root.path());
+        if !probe.ok {
+            return Err(format!("probe not ok: {probe:?}").into());
+        }
+        assert!(probe.detail.contains("bytes"));
+        Ok(())
+    }
+
+    #[test]
+    fn db_missing_when_no_init() -> TestResult {
+        let root = empty_temp()?;
+        let probe = check_db(root.path());
+        assert!(!probe.ok);
+        assert!(probe.fix.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn db_ok_when_initialized() -> TestResult {
+        let root = empty_temp()?;
+        db::initialize_database(root.path())?;
+        let probe = check_db(root.path());
+        assert!(probe.ok);
+        assert!(probe.detail.contains("nodes"));
+        Ok(())
+    }
+
+    #[test]
+    fn hooks_no_git_is_ok() -> TestResult {
+        let root = empty_temp()?;
+        let probe = check_hooks(root.path());
+        assert!(probe.ok);
+        assert!(probe.detail.contains("not a git"));
+        Ok(())
+    }
+
+    #[test]
+    fn model_presence_absent_when_no_files() -> TestResult {
+        let root = empty_temp()?;
+        // Pin the model dir to the temp project so the global default can't
+        // leak a model file across tests.
+        let coraline_dir = root.path().join(".coraline");
+        fs::create_dir_all(&coraline_dir)?;
+        let models_dir = root.path().join("models");
+        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", models_dir.display());
+        fs::write(coraline_dir.join("config.toml"), config)?;
+        let probe = check_model_presence(root.path());
+        assert!(!probe.ok);
+        let Some(fix) = probe.fix.as_ref() else {
+            return Err("expected fix on missing model".into());
+        };
+        assert!(fix.contains("model download"));
+        Ok(())
+    }
+
+    #[test]
+    fn model_presence_ok_when_file_exists() -> TestResult {
+        let root = empty_temp()?;
+        let coraline_dir = root.path().join(".coraline");
+        fs::create_dir_all(&coraline_dir)?;
+        let models_dir = root.path().join("models");
+        fs::create_dir_all(&models_dir)?;
+        fs::write(models_dir.join("model_int8.onnx"), vec![0u8; 1_000_000])?;
+        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", models_dir.display());
+        fs::write(coraline_dir.join("config.toml"), config)?;
+        let probe = check_model_presence(root.path());
+        assert_eq!(probe.name, "model file");
+        assert!(probe.ok);
+        Ok(())
+    }
+
+    #[test]
+    fn model_state_absent_when_empty_dir() -> TestResult {
+        let root = empty_temp()?;
+        let state = compute_model_state(root.path());
+        assert_eq!(state, ModelState::Absent);
+        Ok(())
+    }
+
+    #[test]
+    fn model_state_present_picks_first_preferred() -> TestResult {
+        let root = empty_temp()?;
+        fs::write(root.path().join("model_int8.onnx"), vec![0u8; 42])?;
+        let state = compute_model_state(root.path());
+        assert_eq!(
+            state,
+            ModelState::Present {
+                name: "model_int8.onnx".to_string(),
+                size_bytes: 42,
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_status_returns_a_non_empty_path() -> TestResult {
+        // We can't assert a specific default model here because `load_toml_config`
+        // merges in the user's global `~/.config/coraline/config.toml`, which
+        // may pin `model_dir` to anything. The XDG-based `global_config_dir()`
+        // is also not cross-platform (see config.rs). The override path is
+        // covered separately; here we just verify the function returns a path.
+        let root = empty_temp()?;
+        let resolved = resolve_status_model_dir(root.path());
+        assert!(resolved.file_name().is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_status_override() -> TestResult {
+        let root = empty_temp()?;
+        let coraline_dir = root.path().join(".coraline");
+        fs::create_dir_all(&coraline_dir)?;
+        let custom = root.path().join("custom-models");
+        fs::create_dir_all(&custom)?;
+        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom.display());
+        fs::write(coraline_dir.join("config.toml"), config)?;
+        let resolved = resolve_status_model_dir(root.path());
+        assert_eq!(resolved, custom);
+        Ok(())
+    }
+
+    #[test]
+    fn report_exit_code_all_ok() {
+        let probes = vec![
+            Probe {
+                name: "a",
+                ok: true,
+                detail: "ok".to_string(),
+                fix: None,
+            },
+            Probe {
+                name: "b",
+                ok: true,
+                detail: "ok".to_string(),
+                fix: None,
+            },
+        ];
+        let report = Report::from_probes(probes);
+        assert_eq!(report.exit_code, 0);
+    }
+
+    #[test]
+    fn report_exit_code_on_failure() {
+        let probes = vec![
+            Probe {
+                name: "a",
+                ok: true,
+                detail: "ok".to_string(),
+                fix: None,
+            },
+            Probe {
+                name: "b",
+                ok: false,
+                detail: "fail".to_string(),
+                fix: Some("fix".to_string()),
+            },
+        ];
+        let report = Report::from_probes(probes);
+        assert_eq!(report.exit_code, 1);
+    }
+
+    #[test]
+    fn probe_json_omits_fix_when_none() -> TestResult {
+        let probe = Probe {
+            name: "test",
+            ok: true,
+            detail: "ok".to_string(),
+            fix: None,
+        };
+        let json = serde_json::to_string(&probe)?;
+        assert!(!json.contains("fix"));
+        Ok(())
+    }
+
+    #[test]
+    fn probe_json_includes_fix_when_some() -> TestResult {
+        let probe = Probe {
+            name: "test",
+            ok: false,
+            detail: "fail".to_string(),
+            fix: Some("coraline init".to_string()),
+        };
+        let json = serde_json::to_string(&probe)?;
+        assert!(json.contains("\"fix\":\"coraline init\""));
+        Ok(())
+    }
+
+    #[test]
+    fn run_all_cheap_probes_in_stable_order() -> TestResult {
+        let root = empty_temp()?;
+        let report = run_all(root.path(), false);
+        let names: Vec<&str> = report.probes.iter().map(|p| p.name).collect();
+        assert_eq!(names, vec!["config", "database", "git hooks", "model file"]);
+        Ok(())
+    }
+
+    /// Deep probes require a real ONNX model on disk. Skipped by default
+    /// since a CI test machine may not have one and the `ort` crate
+    /// can panic on a missing/invalid model. Run with
+    /// `cargo test -- --ignored` to verify locally.
+    #[test]
+    #[ignore = "requires a valid ONNX model on disk; ort may panic on missing model"]
+    fn run_all_deep_includes_three_more_in_stable_order() -> TestResult {
+        let root = empty_temp()?;
+        let report = run_all(root.path(), true);
+        let names: Vec<&str> = report.probes.iter().map(|p| p.name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "config",
+                "database",
+                "git hooks",
+                "model file",
+                "model loads",
+                "inference",
+                "embed coverage",
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn report_json_serializes_structurally() -> TestResult {
+        let report = Report::from_probes(vec![Probe {
+            name: "test",
+            ok: true,
+            detail: "ok".to_string(),
+            fix: None,
+        }]);
+        let json = serde_json::to_string_pretty(&report)?;
+        assert!(json.contains("\"probes\""));
+        assert!(json.contains("\"exit_code\": 0"));
+        Ok(())
+    }
+}

--- a/crates/coraline/src/doctor.rs
+++ b/crates/coraline/src/doctor.rs
@@ -467,6 +467,54 @@ mod tests {
             Ok(())
         }
 
+        /// `check_model_load`/`check_model_inference` both call
+        /// `VectorManager::from_project`, which fails at `find_model_file`
+        /// (no ONNX file in `model_dir`) before ever touching the `ort`
+        /// runtime — so unlike the model-*present* deep probes, these two
+        /// negative cases are safe to run unconditionally (no ONNX Runtime
+        /// dylib needed, no `#[ignore]`).
+        #[test]
+        fn check_model_load_returns_false_when_model_absent() -> TestResult {
+            let root = empty_temp()?;
+            let coraline_dir = root.path().join(".coraline");
+            fs::create_dir_all(&coraline_dir)?;
+            let models_dir = root.path().join("models");
+            let config = format!(
+                "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = '{}'\n",
+                models_dir.display()
+            );
+            fs::write(coraline_dir.join("config.toml"), config)?;
+
+            let probe = check_model_load(root.path());
+            assert_eq!(probe.name, "model loads");
+            assert!(!probe.ok);
+            assert!(probe.detail.contains("load failed"));
+            let Some(fix) = probe.fix.as_ref() else {
+                return Err("expected fix on missing model".into());
+            };
+            assert!(fix.contains("model download"));
+            Ok(())
+        }
+
+        #[test]
+        fn check_model_inference_returns_false_when_model_absent() -> TestResult {
+            let root = empty_temp()?;
+            let coraline_dir = root.path().join(".coraline");
+            fs::create_dir_all(&coraline_dir)?;
+            let models_dir = root.path().join("models");
+            let config = format!(
+                "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = '{}'\n",
+                models_dir.display()
+            );
+            fs::write(coraline_dir.join("config.toml"), config)?;
+
+            let probe = check_model_inference(root.path());
+            assert_eq!(probe.name, "inference");
+            assert!(!probe.ok);
+            assert!(probe.detail.contains("model not loaded"));
+            Ok(())
+        }
+
         #[test]
         fn model_state_absent_when_empty_dir() -> TestResult {
             let root = empty_temp()?;

--- a/crates/coraline/src/doctor.rs
+++ b/crates/coraline/src/doctor.rs
@@ -515,6 +515,42 @@ mod tests {
             Ok(())
         }
 
+        /// Unlike the "absent model" cases above, a *present but corrupt*
+        /// `.onnx` file only fails once `ort` actually attempts to parse
+        /// it — which requires a real ONNX Runtime dylib discoverable on
+        /// the loader path (`DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH` +
+        /// `ORT_DYLIB_PATH`, or a bundled runtime). Without one, `ort`
+        /// panics inside its own dylib-loading code rather than returning
+        /// an `Err`, so this can't run unconditionally like the others.
+        #[test]
+        #[ignore = "requires a real ONNX Runtime dylib on the loader path; ort panics (not Err) if it can't dlopen one"]
+        fn check_model_load_and_inference_return_false_on_corrupt_model() -> TestResult {
+            let root = empty_temp()?;
+            let coraline_dir = root.path().join(".coraline");
+            fs::create_dir_all(&coraline_dir)?;
+            let models_dir = root.path().join("models");
+            fs::create_dir_all(&models_dir)?;
+            // Present, but not a real ONNX model — `ort` should reject this
+            // during session construction, not during file lookup.
+            fs::write(models_dir.join("model_int8.onnx"), b"not a real onnx model")?;
+            let config = format!(
+                "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = '{}'\n",
+                models_dir.display()
+            );
+            fs::write(coraline_dir.join("config.toml"), config)?;
+
+            let load_probe = check_model_load(root.path());
+            assert_eq!(load_probe.name, "model loads");
+            assert!(!load_probe.ok);
+            assert!(load_probe.detail.contains("load failed"));
+
+            let inference_probe = check_model_inference(root.path());
+            assert_eq!(inference_probe.name, "inference");
+            assert!(!inference_probe.ok);
+            assert!(inference_probe.detail.contains("model not loaded"));
+            Ok(())
+        }
+
         #[test]
         fn model_state_absent_when_empty_dir() -> TestResult {
             let root = empty_temp()?;

--- a/crates/coraline/src/doctor.rs
+++ b/crates/coraline/src/doctor.rs
@@ -17,13 +17,16 @@
 //!
 //! Ordering is stable so the output is deterministic.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+use std::path::PathBuf;
 
 use serde::Serialize;
 
 use crate::config;
 use crate::db;
 use crate::sync::GitHooksManager;
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 use crate::vectors;
 
 /// One diagnostic check.
@@ -60,17 +63,28 @@ pub fn run_all(project_root: &Path, deep: bool) -> Report {
         check_config(project_root),
         check_db(project_root),
         check_hooks(project_root),
-        check_model_presence(project_root),
     ];
-    if deep {
-        #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-        {
-            probes.push(check_model_load(project_root));
-            probes.push(check_model_inference(project_root));
-            probes.push(check_embed_coverage(project_root));
-        }
-    }
+    probes.extend(embeddings_probes(project_root, deep));
     Report::from_probes(probes)
+}
+
+/// Model-presence/load/inference/coverage probes. Empty when built without
+/// the `embeddings`/`embeddings-dynamic` feature (the ONNX runtime isn't
+/// available to check against).
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+fn embeddings_probes(project_root: &Path, deep: bool) -> Vec<Probe> {
+    let mut probes = vec![check_model_presence(project_root)];
+    if deep {
+        probes.push(check_model_load(project_root));
+        probes.push(check_model_inference(project_root));
+        probes.push(check_embed_coverage(project_root));
+    }
+    probes
+}
+
+#[cfg(not(any(feature = "embeddings", feature = "embeddings-dynamic")))]
+fn embeddings_probes(_project_root: &Path, _deep: bool) -> Vec<Probe> {
+    Vec::new()
 }
 
 // ─── Cheap probes ────────────────────────────────────────────────────────────
@@ -150,6 +164,7 @@ pub fn check_hooks(project_root: &Path) -> Probe {
 
 /// Check that at least one model variant of the configured model is present
 /// on disk.
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 pub fn check_model_presence(project_root: &Path) -> Probe {
     let (model_name, model_dir) = resolve_status_model(project_root);
     match compute_model_state(&model_dir, &model_name) {
@@ -289,6 +304,7 @@ pub fn check_embed_coverage(project_root: &Path) -> Probe {
 // ─── Model state helpers (shared with `coraline status`) ─────────────────────
 
 /// Embedding-model state, as surfaced by `coraline status`.
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 #[derive(Debug, PartialEq, Eq)]
 pub enum ModelState {
     /// At least one variant in the model's preference order is present.
@@ -298,6 +314,7 @@ pub enum ModelState {
 }
 
 /// Pure lookup of which (if any) variant of `model_name` is present on disk.
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 pub fn compute_model_state(model_dir: &Path, model_name: &str) -> ModelState {
     let Ok(spec) = vectors::model_spec(model_name) else {
         return ModelState::Absent;
@@ -321,6 +338,7 @@ pub fn compute_model_state(model_dir: &Path, model_name: &str) -> ModelState {
 /// back to the default model's global directory
 /// (`~/.config/coraline/models/nomic-embed-text-v1.5/`) if config is
 /// missing, unreadable, or names an unknown model.
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 pub fn resolve_status_model(project_root: &Path) -> (String, PathBuf) {
     let cfg = config::load_toml_config(project_root).unwrap_or_default();
     vectors::resolve_model_dir(&cfg.vectors).unwrap_or_else(|_| {
@@ -399,119 +417,124 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn model_presence_absent_when_no_files() -> TestResult {
-        let root = empty_temp()?;
-        // Pin the model dir to the temp project so the global default can't
-        // leak a model file across tests.
-        let coraline_dir = root.path().join(".coraline");
-        fs::create_dir_all(&coraline_dir)?;
-        let models_dir = root.path().join("models");
-        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", models_dir.display());
-        fs::write(coraline_dir.join("config.toml"), config)?;
-        let probe = check_model_presence(root.path());
-        assert!(!probe.ok);
-        let Some(fix) = probe.fix.as_ref() else {
-            return Err("expected fix on missing model".into());
-        };
-        assert!(fix.contains("model download"));
-        Ok(())
-    }
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    mod embeddings_tests {
+        use super::*;
 
-    #[test]
-    fn model_presence_ok_when_file_exists() -> TestResult {
-        let root = empty_temp()?;
-        let coraline_dir = root.path().join(".coraline");
-        fs::create_dir_all(&coraline_dir)?;
-        let models_dir = root.path().join("models");
-        fs::create_dir_all(&models_dir)?;
-        fs::write(models_dir.join("model_int8.onnx"), vec![0u8; 1_000_000])?;
-        // Pin `model` explicitly (not just `model_dir`) so this test is
-        // deterministic regardless of the developer's real global
-        // ~/.config/coraline/config.toml, which may set `vectors.model` to
-        // a different supported model (e.g. jina-embeddings-v2-base-code)
-        // with its own, non-overlapping variant filenames.
-        let config = format!(
-            "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = \"{}\"\n",
-            models_dir.display()
-        );
-        fs::write(coraline_dir.join("config.toml"), config)?;
-        let probe = check_model_presence(root.path());
-        assert_eq!(probe.name, "model file");
-        assert!(probe.ok);
-        Ok(())
-    }
+        #[test]
+        fn model_presence_absent_when_no_files() -> TestResult {
+            let root = empty_temp()?;
+            // Pin the model dir to the temp project so the global default can't
+            // leak a model file across tests.
+            let coraline_dir = root.path().join(".coraline");
+            fs::create_dir_all(&coraline_dir)?;
+            let models_dir = root.path().join("models");
+            let config = format!("[vectors]\nmodel_dir = \"{}\"\n", models_dir.display());
+            fs::write(coraline_dir.join("config.toml"), config)?;
+            let probe = check_model_presence(root.path());
+            assert!(!probe.ok);
+            let Some(fix) = probe.fix.as_ref() else {
+                return Err("expected fix on missing model".into());
+            };
+            assert!(fix.contains("model download"));
+            Ok(())
+        }
 
-    #[test]
-    fn model_state_absent_when_empty_dir() -> TestResult {
-        let root = empty_temp()?;
-        let state = compute_model_state(root.path(), vectors::DEFAULT_MODEL);
-        assert_eq!(state, ModelState::Absent);
-        Ok(())
-    }
+        #[test]
+        fn model_presence_ok_when_file_exists() -> TestResult {
+            let root = empty_temp()?;
+            let coraline_dir = root.path().join(".coraline");
+            fs::create_dir_all(&coraline_dir)?;
+            let models_dir = root.path().join("models");
+            fs::create_dir_all(&models_dir)?;
+            fs::write(models_dir.join("model_int8.onnx"), vec![0u8; 1_000_000])?;
+            // Pin `model` explicitly (not just `model_dir`) so this test is
+            // deterministic regardless of the developer's real global
+            // ~/.config/coraline/config.toml, which may set `vectors.model` to
+            // a different supported model (e.g. jina-embeddings-v2-base-code)
+            // with its own, non-overlapping variant filenames.
+            let config = format!(
+                "[vectors]\nmodel = \"nomic-embed-text-v1.5\"\nmodel_dir = \"{}\"\n",
+                models_dir.display()
+            );
+            fs::write(coraline_dir.join("config.toml"), config)?;
+            let probe = check_model_presence(root.path());
+            assert_eq!(probe.name, "model file");
+            assert!(probe.ok);
+            Ok(())
+        }
 
-    #[test]
-    fn model_state_present_picks_first_preferred() -> TestResult {
-        let root = empty_temp()?;
-        fs::write(root.path().join("model_int8.onnx"), vec![0u8; 42])?;
-        let state = compute_model_state(root.path(), vectors::DEFAULT_MODEL);
-        assert_eq!(
-            state,
-            ModelState::Present {
-                name: "model_int8.onnx".to_string(),
-                size_bytes: 42,
-            }
-        );
-        Ok(())
-    }
+        #[test]
+        fn model_state_absent_when_empty_dir() -> TestResult {
+            let root = empty_temp()?;
+            let state = compute_model_state(root.path(), vectors::DEFAULT_MODEL);
+            assert_eq!(state, ModelState::Absent);
+            Ok(())
+        }
 
-    #[test]
-    fn model_state_absent_for_unknown_model() -> TestResult {
-        let root = empty_temp()?;
-        fs::write(root.path().join("model_int8.onnx"), vec![0u8; 42])?;
-        let state = compute_model_state(root.path(), "not-a-real-model");
-        assert_eq!(state, ModelState::Absent);
-        Ok(())
-    }
+        #[test]
+        fn model_state_present_picks_first_preferred() -> TestResult {
+            let root = empty_temp()?;
+            fs::write(root.path().join("model_int8.onnx"), vec![0u8; 42])?;
+            let state = compute_model_state(root.path(), vectors::DEFAULT_MODEL);
+            assert_eq!(
+                state,
+                ModelState::Present {
+                    name: "model_int8.onnx".to_string(),
+                    size_bytes: 42,
+                }
+            );
+            Ok(())
+        }
 
-    #[test]
-    fn resolve_status_returns_a_non_empty_path() -> TestResult {
-        // We can't assert a specific default model here because `load_toml_config`
-        // merges in the user's global `~/.config/coraline/config.toml`, which
-        // may pin `model_dir` to anything. The XDG-based `global_config_dir()`
-        // is also not cross-platform (see config.rs). The override path is
-        // covered separately; here we just verify the function returns a path.
-        let root = empty_temp()?;
-        let (_, resolved) = resolve_status_model(root.path());
-        assert!(resolved.file_name().is_some());
-        Ok(())
-    }
+        #[test]
+        fn model_state_absent_for_unknown_model() -> TestResult {
+            let root = empty_temp()?;
+            fs::write(root.path().join("model_int8.onnx"), vec![0u8; 42])?;
+            let state = compute_model_state(root.path(), "not-a-real-model");
+            assert_eq!(state, ModelState::Absent);
+            Ok(())
+        }
 
-    #[test]
-    fn resolve_status_override() -> TestResult {
-        let root = empty_temp()?;
-        let coraline_dir = root.path().join(".coraline");
-        fs::create_dir_all(&coraline_dir)?;
-        let custom = root.path().join("custom-models");
-        fs::create_dir_all(&custom)?;
-        let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom.display());
-        fs::write(coraline_dir.join("config.toml"), config)?;
-        let (_, resolved) = resolve_status_model(root.path());
-        assert_eq!(resolved, custom);
-        Ok(())
-    }
+        #[test]
+        fn resolve_status_returns_a_non_empty_path() -> TestResult {
+            // We can't assert a specific default model here because `load_toml_config`
+            // merges in the user's global `~/.config/coraline/config.toml`, which
+            // may pin `model_dir` to anything. The XDG-based `global_config_dir()`
+            // is also not cross-platform (see config.rs). The override path is
+            // covered separately; here we just verify the function returns a path.
+            let root = empty_temp()?;
+            let (_, resolved) = resolve_status_model(root.path());
+            assert!(resolved.file_name().is_some());
+            Ok(())
+        }
 
-    #[test]
-    fn resolve_status_respects_configured_model() -> TestResult {
-        let root = empty_temp()?;
-        let coraline_dir = root.path().join(".coraline");
-        fs::create_dir_all(&coraline_dir)?;
-        let config = "[vectors]\nmodel = \"jina-embeddings-v2-base-code\"\n";
-        fs::write(coraline_dir.join("config.toml"), config)?;
-        let (model_name, resolved) = resolve_status_model(root.path());
-        assert_eq!(model_name, "jina-embeddings-v2-base-code");
-        assert!(resolved.ends_with("jina-embeddings-v2-base-code"));
-        Ok(())
+        #[test]
+        fn resolve_status_override() -> TestResult {
+            let root = empty_temp()?;
+            let coraline_dir = root.path().join(".coraline");
+            fs::create_dir_all(&coraline_dir)?;
+            let custom = root.path().join("custom-models");
+            fs::create_dir_all(&custom)?;
+            let config = format!("[vectors]\nmodel_dir = \"{}\"\n", custom.display());
+            fs::write(coraline_dir.join("config.toml"), config)?;
+            let (_, resolved) = resolve_status_model(root.path());
+            assert_eq!(resolved, custom);
+            Ok(())
+        }
+
+        #[test]
+        fn resolve_status_respects_configured_model() -> TestResult {
+            let root = empty_temp()?;
+            let coraline_dir = root.path().join(".coraline");
+            fs::create_dir_all(&coraline_dir)?;
+            let config = "[vectors]\nmodel = \"jina-embeddings-v2-base-code\"\n";
+            fs::write(coraline_dir.join("config.toml"), config)?;
+            let (model_name, resolved) = resolve_status_model(root.path());
+            assert_eq!(model_name, "jina-embeddings-v2-base-code");
+            assert!(resolved.ends_with("jina-embeddings-v2-base-code"));
+            Ok(())
+        }
     }
 
     #[test]
@@ -585,7 +608,11 @@ mod tests {
         let root = empty_temp()?;
         let report = run_all(root.path(), false);
         let names: Vec<&str> = report.probes.iter().map(|p| p.name).collect();
-        assert_eq!(names, vec!["config", "database", "git hooks", "model file"]);
+        #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+        let expected = vec!["config", "database", "git hooks", "model file"];
+        #[cfg(not(any(feature = "embeddings", feature = "embeddings-dynamic")))]
+        let expected = vec!["config", "database", "git hooks"];
+        assert_eq!(names, expected);
         Ok(())
     }
 

--- a/crates/coraline/src/lib.rs
+++ b/crates/coraline/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
-// Transitive dependency version conflicts we can't control (base64, getrandom, hashbrown).
-#![allow(clippy::multiple_crate_versions)]
+#![expect(
+    clippy::multiple_crate_versions,
+    reason = "transitive dependency version conflicts we can't control (base64, getrandom, hashbrown)"
+)]
 
 pub mod audit;
 pub mod config;

--- a/crates/coraline/src/lib.rs
+++ b/crates/coraline/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audit;
 pub mod config;
 pub mod context;
 pub mod db;
+pub mod doctor;
 pub mod extraction;
 pub mod graph;
 pub mod logging;

--- a/crates/coraline/src/mcp/mod.rs
+++ b/crates/coraline/src/mcp/mod.rs
@@ -111,7 +111,7 @@ struct ToolContent {
     text: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 enum JsonRpcId {
     String(String),
@@ -435,37 +435,51 @@ impl McpServer {
         }
     }
 
-    fn handle_tools_call(&mut self, id: JsonRpcId, message: &Value, era: Era) -> io::Result<()> {
-        let params = message.get("params");
-
-        if matches!(era, protocol::Era::Modern) {
-            match validate_modern_meta(message) {
-                MetaValidation::Ok => {}
-                MetaValidation::MissingFields(_) => {
-                    return self.send_error(
-                        Some(id),
-                        era,
-                        protocol::codes::INVALID_PARAMS,
-                        "Missing required _meta fields for modern tools/call",
-                        None,
-                    );
-                }
-                MetaValidation::UnsupportedVersion => {
-                    let data = serde_json::json!({
-                        "supported": SUPPORTED_VERSIONS,
-                        "requested": protocol::request_protocol_version(message).unwrap_or(""),
-                    });
-                    return self.send_error(
-                        Some(id),
-                        era,
-                        protocol::codes::UNSUPPORTED_PROTOCOL_VERSION_MODERN,
-                        "Unsupported protocol version",
-                        Some(data),
-                    );
-                }
+    /// Validates `_meta` requirements for a modern-era request.
+    ///
+    /// Returns `Some(result)` when validation failed and an error response
+    /// has already been sent (the caller should return that result
+    /// immediately); returns `None` when the request may proceed.
+    fn check_modern_meta(
+        &mut self,
+        id: &JsonRpcId,
+        message: &Value,
+        era: Era,
+    ) -> Option<io::Result<()>> {
+        if !matches!(era, protocol::Era::Modern) {
+            return None;
+        }
+        match validate_modern_meta(message) {
+            MetaValidation::Ok => None,
+            MetaValidation::MissingFields(_) => Some(self.send_error(
+                Some(id.clone()),
+                era,
+                protocol::codes::INVALID_PARAMS,
+                "Missing required _meta fields for modern tools/call",
+                None,
+            )),
+            MetaValidation::UnsupportedVersion => {
+                let data = serde_json::json!({
+                    "supported": SUPPORTED_VERSIONS,
+                    "requested": protocol::request_protocol_version(message).unwrap_or(""),
+                });
+                Some(self.send_error(
+                    Some(id.clone()),
+                    era,
+                    protocol::codes::UNSUPPORTED_PROTOCOL_VERSION_MODERN,
+                    "Unsupported protocol version",
+                    Some(data),
+                ))
             }
         }
+    }
 
+    fn handle_tools_call(&mut self, id: JsonRpcId, message: &Value, era: Era) -> io::Result<()> {
+        if let Some(result) = self.check_modern_meta(&id, message, era) {
+            return result;
+        }
+
+        let params = message.get("params");
         let Some(params) = params else {
             return self.send_error(
                 Some(id),
@@ -531,13 +545,23 @@ impl McpServer {
             }
             Err(err) => {
                 warn!(tool = %parsed.name, error = %err.message, "tool call failed");
+                let structured = err.recover.as_ref().map(|recover| {
+                    serde_json::json!({
+                        "code": err.code,
+                        "message": err.message,
+                        "recover": {
+                            "command": recover.command,
+                            "docs": recover.docs,
+                        },
+                    })
+                });
                 let tool_result = ToolResult {
                     content: vec![ToolContent {
                         r#type: "text",
                         text: format!("Error: {}", err.message),
                     }],
                     is_error: Some(true),
-                    structured_content: None,
+                    structured_content: structured,
                 };
                 let legacy_payload = serde_json::to_value(tool_result).unwrap_or_default();
                 self.send_result(id, era, legacy_payload)

--- a/crates/coraline/src/mcp/protocol.rs
+++ b/crates/coraline/src/mcp/protocol.rs
@@ -446,7 +446,7 @@ mod tests {
             "method": "tools/call",
             "params": { "_meta": {} }
         });
-        #[allow(clippy::panic)] // test helper — failure is the assertion's job
+        #[expect(clippy::panic, reason = "test helper — failure is the assertion's job")]
         match validate_modern_meta(&msg) {
             MetaValidation::MissingFields(fields) => {
                 assert!(fields.contains(&META_PROTOCOL_VERSION));

--- a/crates/coraline/src/memory.rs
+++ b/crates/coraline/src/memory.rs
@@ -248,7 +248,10 @@ When implementing a new feature, ensure:
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::expect_used)]
+    #![expect(
+        clippy::expect_used,
+        reason = "test assertions: panicking on setup failure is the correct behavior"
+    )]
 
     use super::*;
     use tempfile::TempDir;

--- a/crates/coraline/src/resolution/mod.rs
+++ b/crates/coraline/src/resolution/mod.rs
@@ -20,7 +20,6 @@ pub struct ResolveResult {
 }
 
 impl ReferenceResolver {
-    #[allow(clippy::option_if_let_else)]
     pub fn resolve_unresolved(
         conn: &mut rusqlite::Connection,
         project_root: &Path,
@@ -75,12 +74,9 @@ impl ReferenceResolver {
 
             // If generic resolution found nothing, try framework-specific hints.
             let candidates = if candidates.is_empty() {
-                if let Some(ref from) = from_node {
+                from_node.as_ref().map_or_else(Vec::new, |from| {
                     framework_fallback(conn, project_root, from, &reference.reference_name)
-                        .unwrap_or_default()
-                } else {
-                    candidates
-                }
+                })
             } else {
                 candidates
             };
@@ -130,20 +126,19 @@ fn nodes_from_ids(conn: &rusqlite::Connection, ids: &[String]) -> Vec<Node> {
 }
 
 /// Use framework-specific resolvers to find candidates when name search fails.
-#[allow(clippy::unnecessary_wraps)]
 fn framework_fallback(
     conn: &rusqlite::Connection,
     project_root: &Path,
     from_node: &Node,
     reference_name: &str,
-) -> std::io::Result<Vec<Node>> {
+) -> Vec<Node> {
     // from_node.file_path is relative to the project root
     let from_abs = project_root.join(&from_node.file_path);
     let from_abs_str = from_abs.to_string_lossy();
 
     let hints = frameworks::framework_path_hints(project_root, &from_abs_str, reference_name);
     if hints.is_empty() {
-        return Ok(Vec::new());
+        return Vec::new();
     }
 
     // The last "::" segment is the symbol name we're looking for in those files
@@ -157,7 +152,7 @@ fn framework_fallback(
             candidates.extend(nodes);
         }
     }
-    Ok(candidates)
+    candidates
 }
 
 fn relative_to_root(path: &Path, root: &Path) -> String {

--- a/crates/coraline/src/tools/context_tools.rs
+++ b/crates/coraline/src/tools/context_tools.rs
@@ -75,7 +75,6 @@ impl Tool for BuildContextTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let task = params
             .get("task")
@@ -85,20 +84,20 @@ impl Tool for BuildContextTool {
         let max_nodes = params
             .get("max_nodes")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
         let max_code_blocks = params
             .get("max_code_blocks")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
         let max_code_block_size = params
             .get("max_code_block_size")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
         let include_code = params.get("include_code").and_then(Value::as_bool);
         let traversal_depth = params
             .get("traversal_depth")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
 
         let format = match params.get("format").and_then(Value::as_str) {
             Some("json") => Some(ContextFormat::Json),
@@ -116,7 +115,11 @@ impl Tool for BuildContextTool {
             search_limit: params
                 .get("search_limit")
                 .and_then(Value::as_u64)
-                .map(|n| n as usize),
+                .map(|n| usize::try_from(n).unwrap_or(usize::MAX)),
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "f64 -> f32: no checked TryFrom<f64> for f32 in std"
+            )]
             min_score: params
                 .get("min_score")
                 .and_then(Value::as_f64)

--- a/crates/coraline/src/tools/errors.rs
+++ b/crates/coraline/src/tools/errors.rs
@@ -1,0 +1,79 @@
+#![forbid(unsafe_code)]
+
+//! Structured tool error types with optional recovery payloads.
+//!
+//! The plain [`ToolError`](super::ToolError) carries a `code` + `message` pair.
+//! When a tool knows exactly what the agent (or user) should do next to
+//! recover, it attaches a [`RecoverInfo`] via the `recover` field. The MCP
+//! layer surfaces the full struct (code, message, recover) in
+//! `structured_content` so the agent can branch on it without parsing
+//! free-form text.
+
+use serde::{Deserialize, Serialize};
+
+/// Recovery hint attached to a [`ToolError`](super::ToolError) when the
+/// agent can do something to recover from the failure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoverInfo {
+    /// Command the agent (or user) can run to recover.
+    pub command: String,
+    /// URL to the relevant documentation section.
+    pub docs: String,
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::ToolError;
+
+    #[test]
+    fn recover_info_serializes_with_command_and_docs() -> Result<(), serde_json::Error> {
+        let info = RecoverInfo {
+            command: "coraline model download".to_string(),
+            docs: "https://github.com/greysquirr3l/coraline#embeddings".to_string(),
+        };
+        let json = serde_json::to_string(&info)?;
+        assert!(json.contains("\"command\":\"coraline model download\""));
+        assert!(json.contains("\"docs\":\"https://github.com/greysquirr3l/coraline#embeddings\""));
+        Ok(())
+    }
+
+    #[test]
+    fn embedding_model_missing_creates_recoverable_error() -> Result<(), &'static str> {
+        let err = ToolError::embedding_model_missing(RecoverInfo {
+            command: "coraline model download".to_string(),
+            docs: "https://github.com/greysquirr3l/coraline#embeddings".to_string(),
+        });
+        assert_eq!(err.code, "EMBEDDING_MODEL_MISSING");
+        let recover = err.recover.ok_or("expected recover to be present")?;
+        assert_eq!(recover.command, "coraline model download");
+        assert_eq!(
+            recover.docs,
+            "https://github.com/greysquirr3l/coraline#embeddings"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn tool_error_omits_recover_when_none() -> Result<(), serde_json::Error> {
+        let err = ToolError::internal_error("oops");
+        let json = serde_json::to_string(&err)?;
+        assert!(!json.contains("recover"));
+        Ok(())
+    }
+
+    #[test]
+    fn tool_error_includes_recover_when_present() -> Result<(), serde_json::Error> {
+        let err = ToolError::embedding_model_missing(RecoverInfo {
+            command: "coraline model download".to_string(),
+            docs: "https://example.com".to_string(),
+        });
+        let json = serde_json::to_string(&err)?;
+        assert!(json.contains("\"code\":\"EMBEDDING_MODEL_MISSING\""));
+        assert!(json.contains("\"recover\":"));
+        assert!(json.contains("\"command\":\"coraline model download\""));
+        Ok(())
+    }
+}

--- a/crates/coraline/src/tools/file_tools.rs
+++ b/crates/coraline/src/tools/file_tools.rs
@@ -798,12 +798,18 @@ impl SemanticSearchTool {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("DB error: {e}")))?;
 
-        let stale_count = stale_embedding_count(&conn)
+        let toml_vectors_cfg = crate::config::load_toml_config(&self.project_root)
+            .unwrap_or_default()
+            .vectors;
+        let (model_name, _) = crate::vectors::resolve_model_dir(&toml_vectors_cfg)
+            .map_err(|e| ToolError::internal_error(format!("Model config error: {e}")))?;
+
+        let stale_count = stale_embedding_count(&conn, &model_name)
             .map_err(|e| ToolError::internal_error(format!("Embedding-state check failed: {e}")))?;
 
         if stale_count > 0 {
             let refreshed = if let Some(vm) = vm {
-                refresh_stale_embeddings(&conn, vm).map_err(|e| {
+                refresh_stale_embeddings(&conn, vm, &model_name).map_err(|e| {
                     ToolError::internal_error(format!("Embedding refresh failed: {e}"))
                 })?
             } else {
@@ -812,7 +818,7 @@ impl SemanticSearchTool {
                         "Could not load embedding model: {e}. Download the model and run 'coraline embed' first."
                     ))
                 })?;
-                refresh_stale_embeddings(&conn, &mut vm).map_err(|e| {
+                refresh_stale_embeddings(&conn, &mut vm, &model_name).map_err(|e| {
                     ToolError::internal_error(format!("Embedding refresh failed: {e}"))
                 })?
             };
@@ -858,14 +864,14 @@ struct FreshnessUpdate {
 }
 
 #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-fn stale_embedding_count(conn: &rusqlite::Connection) -> std::io::Result<usize> {
+fn stale_embedding_count(conn: &rusqlite::Connection, model: &str) -> std::io::Result<usize> {
     let count = conn
         .query_row(
             "SELECT COUNT(*)
                FROM nodes n
-          LEFT JOIN vectors v ON v.node_id = n.id
+          LEFT JOIN vectors v ON v.node_id = n.id AND v.model = ?1
               WHERE v.created_at IS NULL OR n.updated_at > v.created_at",
-            [],
+            rusqlite::params![model],
             |row| row.get::<_, i64>(0),
         )
         .map_err(std::io::Error::other)?;
@@ -880,6 +886,7 @@ type StaleNodeRow = (String, String, String, Option<String>, Option<String>);
 fn refresh_stale_embeddings(
     conn: &rusqlite::Connection,
     vm: &mut crate::vectors::VectorManager,
+    model: &str,
 ) -> std::io::Result<usize> {
     // Collect stale nodes into memory first so the statement borrow is released
     // before we open a transaction, allowing all stores to commit atomically.
@@ -888,12 +895,12 @@ fn refresh_stale_embeddings(
             .prepare(
                 "SELECT n.id, n.name, n.qualified_name, n.docstring, n.signature
                    FROM nodes n
-              LEFT JOIN vectors v ON v.node_id = n.id
+              LEFT JOIN vectors v ON v.node_id = n.id AND v.model = ?1
                   WHERE v.created_at IS NULL OR n.updated_at > v.created_at",
             )
             .map_err(std::io::Error::other)?;
 
-        stmt.query_map([], |row| {
+        stmt.query_map(rusqlite::params![model], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
@@ -972,7 +979,10 @@ impl Tool for SemanticSearchTool {
             .and_then(Value::as_u64)
             .and_then(|n| usize::try_from(n).ok())
             .unwrap_or(10);
-        #[allow(clippy::cast_possible_truncation)] // f64→f32: no lossless conversion in std
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "f64->f32: no lossless conversion in std"
+        )]
         let min_similarity = params
             .get("min_similarity")
             .and_then(Value::as_f64)
@@ -980,10 +990,16 @@ impl Tool for SemanticSearchTool {
 
         let mut vm =
             crate::vectors::VectorManager::from_project(&self.project_root).map_err(|e| {
-                ToolError::internal_error(format!(
-                    "Could not load embedding model: {e}. \
-                         Download the model and run 'coraline embed' first."
-                ))
+                let mut err = ToolError::embedding_model_missing(crate::tools::RecoverInfo {
+                    command: "coraline model download".to_string(),
+                    docs: "https://github.com/greysquirr3l/coraline#embeddings".to_string(),
+                });
+                // Attach the underlying error message so the agent can see
+                // WHY the load failed (e.g. tokenizer.json missing).
+                if let Some(r) = err.recover.as_mut() {
+                    r.docs = format!("{} (debug: load failed: {e})", r.docs);
+                }
+                err
             })?;
 
         let freshness = self.maybe_refresh_index_and_embeddings(Some(&mut vm))?;
@@ -995,8 +1011,14 @@ impl Tool for SemanticSearchTool {
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("DB error: {e}")))?;
 
-        let results = crate::vectors::search_similar(&conn, &embedding, limit, min_similarity)
-            .map_err(|e| ToolError::internal_error(format!("Search failed: {e}")))?;
+        let results = crate::vectors::search_similar(
+            &conn,
+            &embedding,
+            vm.model_name(),
+            limit,
+            min_similarity,
+        )
+        .map_err(|e| ToolError::internal_error(format!("Search failed: {e}")))?;
 
         let items: Vec<Value> = results
             .into_iter()
@@ -1032,5 +1054,62 @@ impl Tool for SemanticSearchTool {
             },
             "results": items
         }))
+    }
+}
+
+#[cfg(all(test, any(feature = "embeddings", feature = "embeddings-dynamic")))]
+mod tests {
+    #![expect(
+        clippy::expect_used,
+        reason = "test assertions: panicking on setup failure is the correct behavior"
+    )]
+    use super::stale_embedding_count;
+    use rusqlite::Connection;
+
+    fn seed_node(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO nodes (id, kind, name, qualified_name, file_path, language,
+                start_line, end_line, start_column, end_column, updated_at)
+             VALUES (?1, 'function', ?1, ?1, 'src/lib.rs', 'rust', 1, 1, 0, 0, 100)",
+            [id],
+        )
+        .expect("insert node");
+    }
+
+    fn seed_vector(conn: &Connection, node_id: &str, model: &str, created_at: i64) {
+        conn.execute(
+            "INSERT INTO vectors (node_id, embedding, model, created_at)
+             VALUES (?1, x'00', ?2, ?3)",
+            rusqlite::params![node_id, model, created_at],
+        )
+        .expect("insert vector");
+    }
+
+    #[test]
+    fn stale_embedding_count_ignores_fresh_rows_from_other_models() {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch(crate::db::SCHEMA_SQL)
+            .expect("apply schema");
+
+        seed_node(&conn, "node_a");
+        // Fresh (not stale by timestamp) embedding, but from a different
+        // model — must still count as stale for the model we're checking.
+        seed_vector(&conn, "node_a", "other-model", 200);
+
+        let count = stale_embedding_count(&conn, "nomic-embed-text-v1.5").expect("count stale");
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn stale_embedding_count_zero_when_matching_model_is_fresh() {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch(crate::db::SCHEMA_SQL)
+            .expect("apply schema");
+
+        seed_node(&conn, "node_a");
+        seed_vector(&conn, "node_a", "nomic-embed-text-v1.5", 200);
+
+        let count = stale_embedding_count(&conn, "nomic-embed-text-v1.5").expect("count stale");
+        assert_eq!(count, 0);
     }
 }

--- a/crates/coraline/src/tools/graph_tools.rs
+++ b/crates/coraline/src/tools/graph_tools.rs
@@ -61,7 +61,6 @@ impl Tool for SearchTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let query = params
             .get("query")
@@ -82,7 +81,8 @@ impl Tool for SearchTool {
                 _ => None,
             });
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(10) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(10))
+            .unwrap_or(usize::MAX);
 
         let output_format = params
             .get("output_format")
@@ -180,7 +180,6 @@ impl Tool for CallersTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_id = params
             .get("node_id")
@@ -200,7 +199,8 @@ impl Tool for CallersTool {
                     _ => None,
                 });
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(20))
+            .unwrap_or(usize::MAX);
 
         let output_format = params
             .get("output_format")
@@ -304,7 +304,6 @@ impl Tool for CalleesTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_id = params
             .get("node_id")
@@ -324,7 +323,8 @@ impl Tool for CalleesTool {
                     _ => None,
                 });
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(20))
+            .unwrap_or(usize::MAX);
 
         let output_format = params
             .get("output_format")
@@ -416,7 +416,6 @@ impl Tool for ImpactTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_id = params
             .get("node_id")
@@ -426,11 +425,11 @@ impl Tool for ImpactTool {
         let max_depth = params
             .get("max_depth")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
         let max_nodes = params
             .get("max_nodes")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -543,7 +542,6 @@ impl Tool for FindSymbolTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let pattern = params
             .get("name_pattern")
@@ -560,7 +558,8 @@ impl Tool for FindSymbolTool {
             .and_then(Value::as_bool)
             .unwrap_or(false);
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(10) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(10))
+            .unwrap_or(usize::MAX);
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -661,15 +660,14 @@ impl Tool for GetSymbolsOverviewTool {
             let nodes_fallback = db::get_nodes_by_file(&conn, file_path, None)
                 .map_err(|e| ToolError::internal_error(format!("Failed to get nodes: {e}")))?;
 
-            return build_overview_response(&nodes_fallback, file_path);
+            return Ok(build_overview_response(&nodes_fallback, file_path));
         }
 
-        build_overview_response(&nodes, &abs_path)
+        Ok(build_overview_response(&nodes, &abs_path))
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
-fn build_overview_response(nodes: &[crate::types::Node], file_path: &str) -> ToolResult {
+fn build_overview_response(nodes: &[crate::types::Node], file_path: &str) -> Value {
     use std::collections::HashMap;
 
     let mut by_kind: HashMap<String, Vec<Value>> = HashMap::new();
@@ -701,12 +699,12 @@ fn build_overview_response(nodes: &[crate::types::Node], file_path: &str) -> Too
         })
         .collect();
 
-    Ok(json!({
+    json!({
         "file_path": file_path,
         "symbol_count": nodes.len(),
         "by_kind": by_kind,
         "symbols": symbols,
-    }))
+    })
 }
 
 /// Tool for finding all references to a node
@@ -752,7 +750,6 @@ impl Tool for FindReferencesTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_id = params
             .get("node_id")
@@ -771,7 +768,8 @@ impl Tool for FindReferencesTool {
                 _ => None,
             });
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(50) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(50))
+            .unwrap_or(usize::MAX);
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -946,7 +944,6 @@ impl Tool for DependenciesTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_id = params
             .get("node_id")
@@ -956,11 +953,11 @@ impl Tool for DependenciesTool {
         let depth = params
             .get("depth")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
         let limit = params
             .get("limit")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -1059,7 +1056,6 @@ impl Tool for DependentsTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_id = params
             .get("node_id")
@@ -1069,11 +1065,11 @@ impl Tool for DependentsTool {
         let depth = params
             .get("depth")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
         let limit = params
             .get("limit")
             .and_then(Value::as_u64)
-            .map(|n| n as usize);
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX));
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -1170,7 +1166,6 @@ impl Tool for PathTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         use std::collections::{HashMap, VecDeque};
 
@@ -1184,7 +1179,9 @@ impl Tool for PathTool {
             .and_then(Value::as_str)
             .ok_or_else(|| ToolError::invalid_params("to_id must be a string"))?;
 
-        let max_depth = params.get("max_depth").and_then(Value::as_u64).unwrap_or(6) as usize;
+        let max_depth =
+            usize::try_from(params.get("max_depth").and_then(Value::as_u64).unwrap_or(6))
+                .unwrap_or(usize::MAX);
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -1569,17 +1566,19 @@ impl Tool for BatchCallersTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_ids = params
             .get("node_ids")
             .and_then(Value::as_array)
             .ok_or_else(|| ToolError::invalid_params("node_ids must be an array"))?;
 
-        let limit = params
-            .get("limit_per_node")
-            .and_then(Value::as_u64)
-            .unwrap_or(20) as usize;
+        let limit = usize::try_from(
+            params
+                .get("limit_per_node")
+                .and_then(Value::as_u64)
+                .unwrap_or(20),
+        )
+        .unwrap_or(usize::MAX);
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -1668,17 +1667,19 @@ impl Tool for BatchCalleesTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let node_ids = params
             .get("node_ids")
             .and_then(Value::as_array)
             .ok_or_else(|| ToolError::invalid_params("node_ids must be an array"))?;
 
-        let limit = params
-            .get("limit_per_node")
-            .and_then(Value::as_u64)
-            .unwrap_or(20) as usize;
+        let limit = usize::try_from(
+            params
+                .get("limit_per_node")
+                .and_then(Value::as_u64)
+                .unwrap_or(20),
+        )
+        .unwrap_or(usize::MAX);
 
         let conn = db::open_database(&self.project_root)
             .map_err(|e| ToolError::internal_error(format!("Failed to open database: {e}")))?;
@@ -1779,7 +1780,6 @@ impl Tool for SearchBySignatureTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let pattern = params
             .get("pattern")
@@ -1791,7 +1791,8 @@ impl Tool for SearchBySignatureTool {
             .and_then(Value::as_str)
             .and_then(str_to_node_kind);
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(20))
+            .unwrap_or(usize::MAX);
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
 
         let output_format = params
@@ -1902,7 +1903,6 @@ impl Tool for SearchByDocstringTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let query = params
             .get("query")
@@ -1914,7 +1914,8 @@ impl Tool for SearchByDocstringTool {
             .and_then(Value::as_str)
             .and_then(str_to_node_kind);
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(20))
+            .unwrap_or(usize::MAX);
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
 
         let output_format = params
@@ -2021,7 +2022,6 @@ impl Tool for SearchExportedSymbolsTool {
         })
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn execute(&self, params: Value) -> ToolResult {
         let query = params
             .get("query")
@@ -2033,7 +2033,8 @@ impl Tool for SearchExportedSymbolsTool {
             .and_then(Value::as_str)
             .and_then(str_to_node_kind);
 
-        let limit = params.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+        let limit = usize::try_from(params.get("limit").and_then(Value::as_u64).unwrap_or(20))
+            .unwrap_or(usize::MAX);
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
 
         let output_format = params

--- a/crates/coraline/src/tools/memory_tools.rs
+++ b/crates/coraline/src/tools/memory_tools.rs
@@ -321,7 +321,10 @@ impl Tool for EditMemoryTool {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::expect_used)]
+    #![expect(
+        clippy::expect_used,
+        reason = "test assertions: panicking on setup failure is the correct behavior"
+    )]
 
     use super::*;
     use std::fs;

--- a/crates/coraline/src/tools/mod.rs
+++ b/crates/coraline/src/tools/mod.rs
@@ -9,10 +9,14 @@
 use serde_json::Value;
 use std::collections::HashMap;
 
+pub mod audit_tools;
 pub mod context_tools;
+pub mod errors;
 pub mod file_tools;
 pub mod graph_tools;
 pub mod memory_tools;
+
+pub use errors::RecoverInfo;
 
 /// Output format for tool responses
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -198,10 +202,14 @@ pub fn compact_format_legend() -> Value {
 pub type ToolResult = Result<Value, ToolError>;
 
 /// Error type for tool execution failures
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ToolError {
     pub code: String,
     pub message: String,
+    /// Optional recovery payload. When present, the MCP layer surfaces it
+    /// verbatim in `structured_content` so the agent can act on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recover: Option<RecoverInfo>,
 }
 
 impl ToolError {
@@ -209,6 +217,7 @@ impl ToolError {
         Self {
             code: code.into(),
             message: message.into(),
+            recover: None,
         }
     }
 
@@ -222,6 +231,18 @@ impl ToolError {
 
     pub fn not_found(message: impl Into<String>) -> Self {
         Self::new("not_found", message)
+    }
+
+    /// The semantic-search or any embedding tool failed because the ONNX
+    /// model is not on disk. The `recover` payload tells the agent exactly
+    /// what to do next.
+    pub fn embedding_model_missing(recover: RecoverInfo) -> Self {
+        let cmd = recover.command.clone();
+        Self {
+            code: "EMBEDDING_MODEL_MISSING".to_string(),
+            message: format!("Embedding model is not present. Run `{cmd}` to download it."),
+            recover: Some(recover),
+        }
     }
 }
 
@@ -406,12 +427,7 @@ impl ToolRegistry {
     }
 }
 
-/// Create a default tool registry with all built-in tools
-#[allow(clippy::too_many_lines)]
-pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
-    let mut registry = ToolRegistry::new();
-
-    // Register graph tools
+fn register_graph_tools(registry: &mut ToolRegistry, project_root: &std::path::Path) {
     registry.register(Box::new(graph_tools::SearchTool::new(
         project_root.to_path_buf(),
     )));
@@ -448,8 +464,10 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
     registry.register(Box::new(graph_tools::GetNodeTool::new(
         project_root.to_path_buf(),
     )));
+}
 
-    // Register batch query tools (60% token savings)
+/// Batch query tools (60% token savings)
+fn register_batch_tools(registry: &mut ToolRegistry, project_root: &std::path::Path) {
     registry.register(Box::new(graph_tools::BatchGetNodesTool::new(
         project_root.to_path_buf(),
     )));
@@ -459,8 +477,10 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
     registry.register(Box::new(graph_tools::BatchCalleesTool::new(
         project_root.to_path_buf(),
     )));
+}
 
-    // Register advanced search tools (60% token savings for specialized lookups)
+/// Advanced search tools (60% token savings for specialized lookups)
+fn register_advanced_search_tools(registry: &mut ToolRegistry, project_root: &std::path::Path) {
     registry.register(Box::new(graph_tools::SearchBySignatureTool::new(
         project_root.to_path_buf(),
     )));
@@ -473,8 +493,9 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
     registry.register(Box::new(graph_tools::FindByKindInFileTool::new(
         project_root.to_path_buf(),
     )));
+}
 
-    // Register file tools
+fn register_file_tools(registry: &mut ToolRegistry, project_root: &std::path::Path) {
     registry.register(Box::new(file_tools::ReadFileTool::new(
         project_root.to_path_buf(),
     )));
@@ -482,6 +503,9 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
         project_root.to_path_buf(),
     )));
     registry.register(Box::new(file_tools::GetFileNodesTool::new(
+        project_root.to_path_buf(),
+    )));
+    registry.register(Box::new(file_tools::FindFileTool::new(
         project_root.to_path_buf(),
     )));
     registry.register(Box::new(file_tools::StatusTool::new(
@@ -496,13 +520,10 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
     registry.register(Box::new(file_tools::SyncTool::new(
         project_root.to_path_buf(),
     )));
+}
 
-    // Register context tools
-    registry.register(Box::new(context_tools::BuildContextTool::new(
-        project_root.to_path_buf(),
-    )));
-
-    // Register memory tools (ignore errors if memory system fails to initialize)
+/// Memory tools; errors are ignored if the memory system fails to initialize.
+fn register_memory_tools(registry: &mut ToolRegistry, project_root: &std::path::Path) {
     if let Ok(tool) = memory_tools::WriteMemoryTool::new(project_root) {
         registry.register(Box::new(tool));
     }
@@ -518,20 +539,27 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
     if let Ok(tool) = memory_tools::EditMemoryTool::new(project_root) {
         registry.register(Box::new(tool));
     }
+}
 
-    // Register semantic search only when at least one ONNX model variant is present.
-    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-    let model_dir = {
-        let cfg = crate::config::load_toml_config(project_root).unwrap_or_default();
-        cfg.vectors
-            .model_dir
-            .map_or_else(crate::vectors::global_model_dir, std::path::PathBuf::from)
+/// Registers semantic search only when at least one ONNX model variant is present.
+#[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+fn register_semantic_search_tool(registry: &mut ToolRegistry, project_root: &std::path::Path) {
+    let cfg = crate::config::load_toml_config(project_root).unwrap_or_default();
+    let Ok((model_name, model_dir)) = crate::vectors::resolve_model_dir(&cfg.vectors) else {
+        tracing::warn!(
+            "Semantic search disabled: unknown embedding model '{}' in config.",
+            cfg.vectors.model
+        );
+        return;
     };
-    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
-    if crate::vectors::MODEL_PREFERENCE_ORDER
-        .iter()
-        .any(|name| model_dir.join(name).exists())
-    {
+
+    let has_model = crate::vectors::model_spec(&model_name).is_ok_and(|spec| {
+        spec.preference_order
+            .iter()
+            .any(|name| model_dir.join(name).exists())
+    });
+
+    if has_model {
         registry.register(Box::new(file_tools::SemanticSearchTool::new(
             project_root.to_path_buf(),
         )));
@@ -542,6 +570,25 @@ pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
             model_dir.display()
         );
     }
+}
+
+/// Create a default tool registry with all built-in tools
+pub fn create_default_registry(project_root: &std::path::Path) -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+
+    register_graph_tools(&mut registry, project_root);
+    register_batch_tools(&mut registry, project_root);
+    register_advanced_search_tools(&mut registry, project_root);
+    register_file_tools(&mut registry, project_root);
+    registry.register(Box::new(context_tools::BuildContextTool::new(
+        project_root.to_path_buf(),
+    )));
+    registry.register(Box::new(audit_tools::AuditDocsTool::new(
+        project_root.to_path_buf(),
+    )));
+    register_memory_tools(&mut registry, project_root);
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    register_semantic_search_tool(&mut registry, project_root);
 
     registry
 }

--- a/crates/coraline/src/vectors.rs
+++ b/crates/coraline/src/vectors.rs
@@ -13,22 +13,38 @@
 //! Vector embeddings for semantic code search.
 //!
 //! Generates 768-dimensional embeddings using a locally-stored ONNX model
-//! (nomic-embed-text-v1.5) via the `ort` ONNX Runtime bindings.
+//! via the `ort` ONNX Runtime bindings. Coraline supports multiple embedding
+//! models — see [`SupportedModel`] for the registry.
 //!
 //! ## Quick start
 //!
-//! 1. Download a model into `~/.config/coraline/models/nomic-embed-text-v1.5/`.
-//!    Any of the ONNX variants from `nomic-ai/nomic-embed-text-v1.5` work;
-//!    the smallest usable option is `model_int8.onnx` (137 MB).
-//!    Also copy `tokenizer.json` from the same HuggingFace repo.
+//! 1. Run `coraline model list` to see supported models, then
+//!    `coraline model download` to fetch the default
+//!    (`nomic-embed-text-v1.5`) into `~/.config/coraline/models/<model>/`.
+//!    Pass `--model jina-embeddings-v2-base-code` to opt into the
+//!    code-specialised model instead.
 //! 2. Run `coraline embed` to generate embeddings for all indexed nodes.
 //! 3. Use the `coraline_semantic_search` MCP tool to search by natural language.
+//!
+//! Run `coraline doctor` at any point to check model presence, that it
+//! loads and runs inference, and embed coverage in one pass.
+//!
+//! ## Switching models
+//!
+//! Setting `vectors.model` in `.coraline/config.toml` to a different
+//! supported model does not retroactively re-embed existing nodes. Every
+//! read path (`coraline_semantic_search`, `coraline doctor`'s coverage
+//! probe, staleness checks) filters on the `model` column already stored
+//! per-embedding, so a switch makes every node look unembedded *for the
+//! newly configured model* until `coraline embed` is re-run — the system
+//! self-heals rather than mixing scores across models, but the re-embed
+//! step is not automatic.
 //!
 //! ## Model variant preference order
 //!
 //! When `model_file` is not configured, Coraline picks the first file found
-//! from [`MODEL_PREFERENCE_ORDER`].  This prefers well-quantized variants
-//! (137 MB) over the full f32 model (547 MB).
+//! from the configured model's preference order (see [`SupportedModel`]).
+//! This prefers well-quantized variants over the full f32 model.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -42,23 +58,29 @@ use ort::{
 use rusqlite::{Connection, params};
 use tokenizers::Tokenizer;
 
+use crate::config::VectorsConfig;
 use crate::types::SearchResult;
 
-/// Model identifier for nomic-embed-text-v1.5
+/// Identifier for the default shipped embedding model.
 pub const DEFAULT_MODEL: &str = "nomic-embed-text-v1.5";
 
-/// Output dimension for nomic-embed-text-v1.5.
+/// Output dimension for every currently supported model.
+///
+/// Both `nomic-embed-text-v1.5` and `jina-embeddings-v2-base-code` emit
+/// 768-dim vectors; the constant exists so downstream code doesn't have to
+/// know the model name to allocate buffers.
 pub const EMBEDDING_DIM: usize = 768;
 
 /// Maximum sequence length fed to the model (tokens).
-/// nomic-embed-text-v1.5 supports up to 8192, but 512 covers most code snippets.
+/// Supported models handle much longer contexts, but 512 covers most code
+/// snippets without inflating ONNX session memory.
 pub const MAX_SEQ_LEN: usize = 512;
 
-/// ONNX model file names tried in order when `model_file` is not configured.
+/// ONNX preference order for nomic-embed-text-v1.5.
 ///
-/// Preference is given to quantized variants (smaller on disk, faster to load)
-/// before falling back to the full f32 model.
-pub const MODEL_PREFERENCE_ORDER: &[&str] = &[
+/// Preference is given to quantized variants (smaller on disk, faster to
+/// load) before falling back to the full f32 model.
+const NOMIC_PREFERENCE_ORDER: &[&str] = &[
     "model_int8.onnx",      // 137 MB  — int8 quantized (recommended)
     "model_quantized.onnx", // 137 MB  — same weights, different name
     "model_uint8.onnx",     // 137 MB  — uint8 quantized
@@ -69,12 +91,107 @@ pub const MODEL_PREFERENCE_ORDER: &[&str] = &[
     "model.onnx",           // 547 MB  — full f32 (fallback)
 ];
 
-/// Find the best available ONNX model file in `model_dir`.
+/// ONNX preference order for jina-embeddings-v2-base-code.
+const JINA_CODE_PREFERENCE_ORDER: &[&str] = &[
+    "model_quantized.onnx", // 162 MB — int8 quantized (recommended)
+    "model_fp16.onnx",      // 321 MB — fp16
+    "model.onnx",           // 642 MB — full f32 (fallback)
+];
+
+/// Retained for backward compatibility with callers that assume the
+/// default (nomic) model. Prefer calling [`model_spec`] and reading
+/// `preference_order` off the result.
+pub const MODEL_PREFERENCE_ORDER: &[&str] = NOMIC_PREFERENCE_ORDER;
+
+/// One entry in the embedding-model registry: everything needed to
+/// download and run a supported ONNX model.
+#[derive(Debug, Clone, Copy)]
+pub struct SupportedModel {
+    /// Canonical model name (matches the `HuggingFace` repo slug and the
+    /// `vectors.model` config value).
+    pub name: &'static str,
+    /// `HuggingFace` `resolve/main` base URL for the repo.
+    pub hf_base_url: &'static str,
+    /// ONNX filename to download by default (e.g. when running
+    /// `coraline model download` with no `--variant`).
+    pub default_filename: &'static str,
+    /// Filenames tried in order when auto-detecting an installed variant.
+    pub preference_order: &'static [&'static str],
+    /// Embedding vector dimension produced by the model.
+    pub dimension: usize,
+    /// Short human-readable description (shown by `coraline model list`).
+    pub description: &'static str,
+}
+
+/// Registry of every model Coraline knows how to download and run.
+///
+/// `nomic-embed-text-v1.5` is the default; other entries are opt-in via
+/// `vectors.model` in `.coraline/config.toml`.
+pub const SUPPORTED_MODELS: &[SupportedModel] = &[
+    SupportedModel {
+        name: DEFAULT_MODEL,
+        hf_base_url: "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/resolve/main",
+        default_filename: "model_int8.onnx",
+        preference_order: NOMIC_PREFERENCE_ORDER,
+        dimension: 768,
+        description: "General-purpose English text embeddings (137 MB int8, default).",
+    },
+    SupportedModel {
+        name: "jina-embeddings-v2-base-code",
+        hf_base_url: "https://huggingface.co/jinaai/jina-embeddings-v2-base-code/resolve/main",
+        default_filename: "model_quantized.onnx",
+        preference_order: JINA_CODE_PREFERENCE_ORDER,
+        dimension: 768,
+        description: "Code-specialised embeddings (162 MB int8). \
+                       Trained on code/docstring pairs across 30+ languages.",
+    },
+];
+
+/// Look up a model in [`SUPPORTED_MODELS`] by name.
+pub fn model_spec(name: &str) -> io::Result<&'static SupportedModel> {
+    SUPPORTED_MODELS
+        .iter()
+        .find(|m| m.name == name)
+        .ok_or_else(|| {
+            let known: Vec<&str> = SUPPORTED_MODELS.iter().map(|m| m.name).collect();
+            io::Error::other(format!(
+                "Unknown embedding model '{name}'. Supported models: {}",
+                known.join(", ")
+            ))
+        })
+}
+
+/// Resolve the configured model name and its on-disk directory.
+///
+/// This is the single source of truth for "which model, and where are its
+/// files": every model-aware call site (`coraline doctor`, `coraline
+/// status`, `coraline model`, `coraline embed`, semantic search
+/// registration) should go through this instead of duplicating the
+/// override-else-default pattern.
+///
+/// Validates `cfg.model` against [`SUPPORTED_MODELS`] (a typo surfaces here,
+/// not as a confusing download/load failure downstream). Directory
+/// resolution: `cfg.model_dir` override if set, else
+/// `~/.config/coraline/models/<model>/`.
+pub fn resolve_model_dir(cfg: &VectorsConfig) -> io::Result<(String, PathBuf)> {
+    model_spec(&cfg.model)?;
+    let dir = cfg
+        .model_dir
+        .as_deref()
+        .map_or_else(|| global_model_dir_for(&cfg.model), PathBuf::from);
+    Ok((cfg.model.clone(), dir))
+}
+
+/// Find the best available ONNX model file in `model_dir` for `model_name`.
 ///
 /// If `preferred` is `Some(name)`, that exact filename is required (error if
-/// absent).  Otherwise, the first filename from [`MODEL_PREFERENCE_ORDER`]
-/// that exists in the directory is returned.
-pub fn find_model_file(model_dir: &Path, preferred: Option<&str>) -> io::Result<PathBuf> {
+/// absent). Otherwise, the first filename from `model_name`'s preference
+/// order that exists in the directory is returned.
+pub fn find_model_file(
+    model_dir: &Path,
+    model_name: &str,
+    preferred: Option<&str>,
+) -> io::Result<PathBuf> {
     if let Some(name) = preferred {
         let p = model_dir.join(name);
         if p.exists() {
@@ -85,7 +202,8 @@ pub fn find_model_file(model_dir: &Path, preferred: Option<&str>) -> io::Result<
             model_dir.display()
         )));
     }
-    for name in MODEL_PREFERENCE_ORDER {
+    let spec = model_spec(model_name)?;
+    for name in spec.preference_order {
         let p = model_dir.join(name);
         if p.exists() {
             return Ok(p);
@@ -93,31 +211,65 @@ pub fn find_model_file(model_dir: &Path, preferred: Option<&str>) -> io::Result<
     }
     Err(io::Error::other(format!(
         "No ONNX model file found in {}. \
-         Download a model variant (e.g. model_int8.onnx) from \
-         huggingface.co/nomic-ai/nomic-embed-text-v1.5 and copy \
-         tokenizer.json alongside it.",
-        model_dir.display()
+         Download a model variant (e.g. {}) from {} \
+         and copy tokenizer.json alongside it.",
+        model_dir.display(),
+        spec.default_filename,
+        spec.hf_base_url,
     )))
 }
 
 // ── HuggingFace download ──────────────────────────────────────────────────────
 
 /// HuggingFace repository base URL for nomic-embed-text-v1.5.
+///
+/// Retained for callers that don't pass a model name. Prefer looking up
+/// `model_spec(name).hf_base_url`.
 pub const HF_BASE_URL: &str = "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/resolve/main";
 
-/// HuggingFace download URL for `tokenizer.json`.
+/// HuggingFace download URL for `tokenizer.json` of `model_name`.
+pub fn tokenizer_url_for(model_name: &str) -> io::Result<String> {
+    Ok(format!(
+        "{}/tokenizer.json",
+        model_spec(model_name)?.hf_base_url
+    ))
+}
+
+/// HuggingFace download URL for `tokenizer_config.json` of `model_name`.
+pub fn tokenizer_config_url_for(model_name: &str) -> io::Result<String> {
+    Ok(format!(
+        "{}/tokenizer_config.json",
+        model_spec(model_name)?.hf_base_url
+    ))
+}
+
+/// HuggingFace download URL for a specific ONNX model variant of `model_name`.
+///
+/// ONNX files live under the `onnx/` subdirectory in the HF repo.
+pub fn model_url_for(model_name: &str, filename: &str) -> io::Result<String> {
+    Ok(format!(
+        "{}/onnx/{filename}",
+        model_spec(model_name)?.hf_base_url
+    ))
+}
+
+/// HuggingFace download URL for `tokenizer.json` of the default model.
+///
+/// Retained for callers that don't pass a model name. Prefer [`tokenizer_url_for`].
 pub fn tokenizer_url() -> String {
     format!("{HF_BASE_URL}/tokenizer.json")
 }
 
-/// HuggingFace download URL for `tokenizer_config.json`.
+/// HuggingFace download URL for `tokenizer_config.json` of the default model.
+///
+/// Retained for callers that don't pass a model name. Prefer [`tokenizer_config_url_for`].
 pub fn tokenizer_config_url() -> String {
     format!("{HF_BASE_URL}/tokenizer_config.json")
 }
 
-/// HuggingFace download URL for a specific ONNX model variant.
+/// HuggingFace download URL for a specific ONNX variant of the default model.
 ///
-/// ONNX files live under the `onnx/` subdirectory in the HF repo.
+/// Retained for callers that don't pass a model name. Prefer [`model_url_for`].
 pub fn model_url(filename: &str) -> String {
     format!("{HF_BASE_URL}/onnx/{filename}")
 }
@@ -189,28 +341,44 @@ pub fn download_to_file(url: &str, dest: &Path, label: &str, quiet: bool) -> io:
     Ok(())
 }
 
-/// Download all files needed to run the embedding model into `model_dir`.
+/// Download all files needed to run `model_name` into `model_dir`.
 ///
 /// Downloads:
 /// - `tokenizer.json` and `tokenizer_config.json` (HF repo root)
 /// - `<model_filename>` ONNX weights (HF `onnx/` subdirectory)
+///
+/// `model_filename` must be one of `model_spec(model_name)?.preference_order`
+/// — a filename from a different model family will fail with a clear error
+/// before any network request is made.
 ///
 /// Set `skip_existing = true` to skip files that are already present on disk.
 ///
 /// Available with the `embeddings` and `embeddings-dynamic` features.
 #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
 pub fn download_model(
+    model_name: &str,
     model_dir: &Path,
     model_filename: &str,
     skip_existing: bool,
     quiet: bool,
 ) -> io::Result<()> {
+    let spec = model_spec(model_name)?;
+    if !spec.preference_order.contains(&model_filename) {
+        return Err(io::Error::other(format!(
+            "'{model_filename}' is not a known variant of '{model_name}'. Valid variants: {}",
+            spec.preference_order.join(", ")
+        )));
+    }
+
     std::fs::create_dir_all(model_dir)?;
 
     // Small files — always at repo root on HF
     let meta_files = [
-        ("tokenizer.json", tokenizer_url()),
-        ("tokenizer_config.json", tokenizer_config_url()),
+        ("tokenizer.json", tokenizer_url_for(model_name)?),
+        (
+            "tokenizer_config.json",
+            tokenizer_config_url_for(model_name)?,
+        ),
     ];
     for (name, url) in &meta_files {
         let dest = model_dir.join(name);
@@ -230,7 +398,7 @@ pub fn download_model(
             println!("  {model_filename}: already present, skipping");
         }
     } else {
-        let url = model_url(model_filename);
+        let url = model_url_for(model_name, model_filename)?;
         download_to_file(&url, &dest, model_filename, quiet)?;
     }
 
@@ -255,7 +423,11 @@ impl VectorManager {
     /// Load the manager from an ONNX model file.
     ///
     /// Expects `tokenizer.json` in the same directory as `model_path`.
-    pub fn new(model_path: &Path) -> io::Result<Self> {
+    /// `model_name` is stored so [`store_embedding`] tags rows with the
+    /// model that actually produced them — critical for `search_similar`,
+    /// staleness, and coverage filters to stay correct across model
+    /// switches.
+    pub fn new(model_path: &Path, model_name: &str) -> io::Result<Self> {
         let session = Session::builder()
             .map_err(io::Error::other)?
             .with_optimization_level(GraphOptimizationLevel::Level3)
@@ -292,37 +464,38 @@ impl VectorManager {
         Ok(Self {
             session,
             tokenizer,
-            model_name: DEFAULT_MODEL.to_string(),
+            model_name: model_name.to_string(),
             output_name,
             has_token_type_ids,
         })
     }
 
-    /// Load from a directory, auto-detecting the best available model variant.
+    /// Load from a directory, auto-detecting the best available model variant
+    /// of `model_name`.
     ///
-    /// Uses [`find_model_file`] with no preference, so it picks the first file
-    /// from [`MODEL_PREFERENCE_ORDER`] that exists in `model_dir`.
-    pub fn from_dir(model_dir: &Path) -> io::Result<Self> {
-        let model_path = find_model_file(model_dir, None)?;
-        Self::new(&model_path)
+    /// Uses [`find_model_file`] with no preference, so it picks the first
+    /// file from `model_name`'s preference order that exists in `model_dir`.
+    pub fn from_dir(model_dir: &Path, model_name: &str) -> io::Result<Self> {
+        let model_path = find_model_file(model_dir, model_name, None)?;
+        Self::new(&model_path, model_name)
     }
 
-    /// Load using the project's config (falls back to [`global_model_dir`]).
+    /// Load using the project's config (falls back to the default model's
+    /// global directory).
     ///
-    /// Respects `vectors.model_dir` and `vectors.model_file` from config.toml.
-    /// Lazily migrates model files from the legacy per-project location when
-    /// the global directory has no model yet.
+    /// Respects `vectors.model`, `vectors.model_dir`, and `vectors.model_file`
+    /// from config.toml via [`resolve_model_dir`]. Lazily migrates model
+    /// files from the legacy per-project nomic location when the global
+    /// nomic directory has no model yet.
     pub fn from_project(project_root: &Path) -> io::Result<Self> {
         let cfg = crate::config::load_toml_config(project_root).unwrap_or_default();
-        let model_dir = cfg
-            .vectors
-            .model_dir
-            .map_or_else(global_model_dir, PathBuf::from);
+        let (model_name, model_dir) = resolve_model_dir(&cfg.vectors)?;
 
         maybe_migrate_legacy_model(&global_model_dir(), project_root);
 
-        let model_path = find_model_file(&model_dir, cfg.vectors.model_file.as_deref())?;
-        Self::new(&model_path)
+        let model_path =
+            find_model_file(&model_dir, &model_name, cfg.vectors.model_file.as_deref())?;
+        Self::new(&model_path, &model_name)
     }
 
     /// Generate a normalised embedding vector for `text`.
@@ -382,14 +555,21 @@ impl VectorManager {
     }
 }
 
-/// Shared model directory: `$XDG_CONFIG_HOME/coraline/models/nomic-embed-text-v1.5/`.
+/// Shared model directory: `$XDG_CONFIG_HOME/coraline/models/<model_name>/`.
 ///
-/// Falls back to `~/.config/coraline/models/nomic-embed-text-v1.5/` when
+/// Falls back to `~/.config/coraline/models/<model_name>/` when
 /// `XDG_CONFIG_HOME` is not set.
-pub fn global_model_dir() -> PathBuf {
+pub fn global_model_dir_for(model_name: &str) -> PathBuf {
     crate::config::global_config_dir()
         .join("models")
-        .join(DEFAULT_MODEL)
+        .join(model_name)
+}
+
+/// Shared model directory for the default (nomic) model.
+///
+/// Retained for callers that don't pass a model name. Prefer [`global_model_dir_for`].
+pub fn global_model_dir() -> PathBuf {
+    global_model_dir_for(DEFAULT_MODEL)
 }
 
 /// Default model directory for a project.
@@ -406,6 +586,10 @@ pub fn default_model_dir(_project_root: &Path) -> PathBuf {
 /// tokenizer files. If `global_dir` already contains any model file the function
 /// returns immediately. Prints one informational message when files are copied so
 /// users know where the model now lives and how to clean up the old location.
+///
+/// This is deliberately nomic-only: the legacy per-project model layout
+/// predates multi-model support entirely, so there is nothing to migrate
+/// for any other model.
 pub fn maybe_migrate_legacy_model(global_dir: &Path, project_root: &Path) {
     let already_present = MODEL_PREFERENCE_ORDER
         .iter()
@@ -648,6 +832,10 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 ///
 /// * `conn` - Database connection
 /// * `query_embedding` - The query embedding vector
+/// * `model` - Model name to restrict results to (matches the `vectors.model`
+///   column stored by [`store_embedding`]); prevents comparing a query
+///   embedding against rows written by a different, previously-configured
+///   model
 /// * `limit` - Maximum number of results to return
 /// * `min_similarity` - Minimum cosine similarity threshold (0.0 to 1.0)
 ///
@@ -657,6 +845,7 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 pub fn search_similar(
     conn: &Connection,
     query_embedding: &[f32],
+    model: &str,
     limit: usize,
     min_similarity: f32,
 ) -> io::Result<Vec<SearchResult>> {
@@ -669,12 +858,13 @@ pub fn search_similar(
                          n.is_exported, n.is_async, n.is_static, n.is_abstract,
                          n.decorators, n.type_parameters
                   FROM vectors v
-                  JOIN nodes n ON v.node_id = n.id",
+                  JOIN nodes n ON v.node_id = n.id
+                  WHERE v.model = ?1",
         )
         .map_err(|e| io::Error::other(format!("Failed to prepare query: {}", e)))?;
 
     let rows = stmt
-        .query_map([], |row| {
+        .query_map(params![model], |row| {
             let embedding_bytes: Vec<u8> = row.get(1)?;
 
             // Convert bytes to f32 vector
@@ -875,5 +1065,74 @@ mod tests {
         let b: Vec<f32> = vec![];
         let sim = cosine_similarity(&a, &b);
         assert_eq!(sim, 0.0);
+    }
+
+    // ── Model registry ───────────────────────────────────────────────────────
+
+    #[test]
+    fn model_spec_finds_known_models() {
+        assert!(model_spec(DEFAULT_MODEL).is_ok());
+        assert!(model_spec("jina-embeddings-v2-base-code").is_ok());
+    }
+
+    #[test]
+    fn model_spec_errors_on_unknown_model_with_known_list() {
+        let err = model_spec("not-a-real-model").unwrap_err().to_string();
+        assert!(err.contains("not-a-real-model"));
+        assert!(err.contains(DEFAULT_MODEL));
+        assert!(err.contains("jina-embeddings-v2-base-code"));
+    }
+
+    #[test]
+    fn resolve_model_dir_uses_configured_model_by_default() {
+        let cfg = VectorsConfig {
+            model: "jina-embeddings-v2-base-code".to_string(),
+            model_dir: None,
+            ..VectorsConfig::default()
+        };
+        let (name, dir) = resolve_model_dir(&cfg).unwrap();
+        assert_eq!(name, "jina-embeddings-v2-base-code");
+        assert!(dir.ends_with("jina-embeddings-v2-base-code"));
+    }
+
+    #[test]
+    fn resolve_model_dir_respects_model_dir_override() {
+        let cfg = VectorsConfig {
+            model: DEFAULT_MODEL.to_string(),
+            model_dir: Some("/tmp/custom-model-dir".to_string()),
+            ..VectorsConfig::default()
+        };
+        let (name, dir) = resolve_model_dir(&cfg).unwrap();
+        assert_eq!(name, DEFAULT_MODEL);
+        assert_eq!(dir, PathBuf::from("/tmp/custom-model-dir"));
+    }
+
+    #[test]
+    fn resolve_model_dir_errors_on_unknown_model() {
+        let cfg = VectorsConfig {
+            model: "not-a-real-model".to_string(),
+            ..VectorsConfig::default()
+        };
+        assert!(resolve_model_dir(&cfg).is_err());
+    }
+
+    #[cfg(any(feature = "embeddings", feature = "embeddings-dynamic"))]
+    #[test]
+    fn download_model_rejects_variant_from_a_different_model_family() {
+        let dir = std::env::temp_dir().join("coraline-test-download-model-mismatch");
+        // A nomic-only filename passed for the jina model must be rejected
+        // before any network request is attempted (no files should appear).
+        let err = download_model(
+            "jina-embeddings-v2-base-code",
+            &dir,
+            "model_int8.onnx",
+            true,
+            true,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("model_int8.onnx"));
+        assert!(err.contains("jina-embeddings-v2-base-code"));
+        assert!(!dir.exists());
     }
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -22,6 +22,7 @@ When `[PATH]` is omitted, the current working directory is used as the project r
 | `impact` | Analyze change impact radius |
 | `config` | Read or update configuration |
 | `hooks` | Manage git hooks |
+| `doctor` | Run diagnostic checks (config, database, model, embed coverage) |
 | `serve` | Start the MCP server |
 | `update` | Check for available updates on crates.io |
 | `embed` | Generate vector embeddings for indexed nodes |
@@ -33,7 +34,7 @@ When `[PATH]` is omitted, the current working directory is used as the project r
 
 Initialize Coraline in a project directory. Creates `.coraline/` with a SQLite database, default `config.toml`, and initial memory templates.
 
-When stdin is a TTY, prompts to download the embedding model (~137 MB) after initialization. Decline to skip — all non-embedding tools remain fully functional and you can download later with `coraline model download`.
+When stdin is a TTY and no model decision flag is given, prompts to download the embedding model (~137 MB) after initialization. Decline to skip — all non-embedding tools remain fully functional and you can download later with `coraline model download`. Use `--embed`, `--no-embed`, or `--yes` to make the decision non-interactively (see below); if the model is already present on disk, `init` skips the prompt entirely regardless of flags.
 
 If `.coraline/` already exists and `--index` is passed **without** `--force`, `init` skips the overwrite and runs indexing directly on the existing project.
 
@@ -44,6 +45,9 @@ If `.coraline/` already exists and `--index` is passed **without** `--force`, `i
 | `-i`, `--index` | Run a full index immediately after initialization |
 | `-f`, `--force` | Overwrite an existing `.coraline/` directory without prompting |
 | `--no-hooks` | Skip automatic git hook installation |
+| `--embed` | Download the embedding model during init (skips the TTY prompt) |
+| `--no-embed` | Skip the embedding model entirely — no prompt, no download. Conflicts with `--embed` and always wins over `--yes` |
+| `-y`, `--yes` | Non-interactive mode: auto-accept the model download prompt |
 
 **Examples:**
 ```bash
@@ -52,7 +56,12 @@ coraline init /path/to/my-app   # Initialize a specific path
 coraline init -i                 # Initialize, prompt for model, then index
 coraline init -i --no-hooks      # Initialize and index, skip git hooks
 coraline init --force            # Wipe and reinitialize existing project
+coraline init --embed            # Initialize and download the embedding model, no prompt
+coraline init --no-embed         # Initialize, skip the model entirely, no prompt
+coraline init --yes              # Initialize non-interactively; auto-downloads the model
 ```
+
+> Which model is downloaded is controlled by `vectors.model` in config (default `nomic-embed-text-v1.5`), not by an `init` flag — see `coraline model` below and the `[vectors]` section in [CONFIGURATION.md](CONFIGURATION.md).
 
 **On success, creates:**
 - `.coraline/coraline.db` — SQLite knowledge graph
@@ -104,7 +113,7 @@ coraline sync -q                 # Silent sync (used by git hook)
 
 ## `coraline status [PATH]`
 
-Show the current project status: initialization state, paths to config and database, database size, and git hook status.
+Show the current project status: initialization state, paths to config and database, database size, embedding-model state, and git hook status.
 
 **Examples:**
 ```bash
@@ -118,8 +127,13 @@ Coraline Status
 Project: /home/user/my-app
 Config:  /home/user/my-app/.coraline/config.toml
 Database: /home/user/my-app/.coraline/coraline.db (1048576 bytes)
+Embeddings: model_quantized.onnx (161 MB)
+Model:      jina-embeddings-v2-base-code
+Model dir:  /home/user/.config/coraline/models/jina-embeddings-v2-base-code
 Git hooks: installed
 ```
+
+The `Embeddings` line shows `not present` (with a fix hint) when no model file has been downloaded yet for the project's configured model (`vectors.model`, default `nomic-embed-text-v1.5`). See `coraline model` and `coraline doctor` below.
 
 ---
 
@@ -323,6 +337,63 @@ coraline hooks remove
 
 ---
 
+## `coraline doctor [PATH]`
+
+Run diagnostic checks against a project and report pass/fail per check, with a fix hint for anything failing. Exits `0` if every check passed, `1` otherwise — safe to use as a CI gate.
+
+**Checks (in order):**
+
+| Check | What it verifies |
+|---|---|
+| `config` | `.coraline/config.toml` exists and is readable |
+| `database` | `.coraline/coraline.db` opens and returns stats (node/edge/file counts) |
+| `git hooks` | The post-commit hook is installed (or the project isn't a git repo, which is fine) |
+| `model file` | At least one ONNX variant of the configured model (`vectors.model`) is present on disk |
+| `model loads` *(deep only)* | The ONNX model actually loads into an inference session |
+| `inference` *(deep only)* | A sample embedding runs through the loaded model successfully |
+| `embed coverage` *(deep only)* | Every indexed node has an embedding for the configured model |
+
+The three deep checks require a build with the `embeddings` or `embeddings-dynamic` feature; they're skipped (not failed) on builds without it.
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--quick` | Skip the three deep model-load/inference/coverage checks (fast, no ONNX runtime needed) |
+| `--deep` | Explicit deep mode — this is already the default; mutually exclusive with `--quick` |
+| `--json` | Print the report as JSON instead of the human-readable `✔`/`✘` list |
+
+**Examples:**
+```bash
+coraline doctor                  # Full diagnostic run (deep checks included)
+coraline doctor --quick          # Skip slow model checks — good for CI
+coraline doctor --json           # Machine-readable report
+```
+
+**Sample output:**
+```
+✔  config
+✔  database
+✔  git hooks
+✘  model file
+    → Run `coraline model download`.
+```
+
+**Sample `--json` output:**
+```json
+{
+  "probes": [
+    { "name": "config", "ok": true, "detail": "/path/.coraline/config.toml (3775 bytes)" },
+    { "name": "database", "ok": true, "detail": "/path/.coraline/coraline.db (2 nodes, 1 edges, 1 files)" },
+    { "name": "git hooks", "ok": true, "detail": "installed" },
+    { "name": "model file", "ok": false, "detail": "no model file for 'nomic-embed-text-v1.5' in ...", "fix": "Run `coraline model download`." }
+  ],
+  "exit_code": 1
+}
+```
+
+---
+
 ## `coraline serve [PATH]`
 
 Start the MCP server. With `--mcp`, communicates over stdio using the Model Context Protocol.
@@ -386,49 +457,56 @@ Logs are written to `.coraline/logs/coraline.log` (daily rotating) and to stderr
 
 ## `coraline embed [PATH]`
 
-Generate vector embeddings for all indexed nodes using the local ONNX model. Embeddings enable the `coraline_semantic_search` MCP tool.
+Generate vector embeddings for every currently indexed node using the local ONNX model. Embeddings enable the `coraline_semantic_search` MCP tool.
 
-By default, `embed` performs a lightweight freshness check and runs incremental `sync` first when indexed state is stale. This keeps embeddings aligned with current source files without requiring a manual `coraline sync` step.
+`embed` does not run `sync` itself — run `coraline sync` (or `coraline index`) first if source files have changed since the last index. The `coraline_semantic_search` MCP tool, by contrast, performs its own lightweight freshness check and incremental sync/re-embed on each call, so MCP clients don't need a manual `coraline sync` step.
 
 **Options:**
 
 | Flag | Description |
 |---|---|
 | `--download` | Download the model automatically before embedding |
-| `--variant FILENAME` | ONNX variant to download (default: `model_int8.onnx`) |
-| `--skip-sync` | Skip automatic pre-embed sync check (embeddings may be stale) |
+| `--variant FILENAME` | ONNX variant to download (default: the configured model's recommended variant) |
 | `--batch-size N` | Nodes per progress batch (default: `50`) |
 | `-q`, `--quiet` | Suppress progress output |
 
 **Examples:**
 ```bash
 coraline embed                        # Embed using already-downloaded model
-coraline embed --skip-sync            # Skip auto-sync and embed current index state
-coraline embed --download             # Download model_int8.onnx then embed
+coraline embed --download             # Download the configured model then embed
 coraline embed --download --variant model_fp16.onnx
 ```
 
-Run `coraline index` first. Models are stored in `.coraline/models/nomic-embed-text-v1.5/`.
+Run `coraline index` first. Uses the model configured by `vectors.model` (default `nomic-embed-text-v1.5`), stored in `~/.config/coraline/models/<model>/` — see `coraline model list`.
 
 ---
 
 ## `coraline model [PATH]`
 
-Manage the ONNX embedding model files.
+Manage embedding model files. Supports multiple models — run `coraline model list` to see the registry.
+
+### `coraline model list`
+
+List every embedding model Coraline knows how to download and run, with dimension and description.
+
+```bash
+coraline model list
+```
 
 ### `coraline model download`
 
-Download model files from HuggingFace (`nomic-ai/nomic-embed-text-v1.5`).
+Download model files from HuggingFace.
 
 | Flag | Description |
 |---|---|
-| `--variant FILENAME` | ONNX variant to download (default: `model_int8.onnx`) |
+| `--model NAME` | Which supported model to download (default: `vectors.model` from config.toml) |
+| `--variant FILENAME` | ONNX variant to download (default: the model's recommended variant) |
 | `-f`, `--force` | Re-download even if files already exist |
 | `-q`, `--quiet` | Suppress progress output |
 
-Downloads `tokenizer.json`, `tokenizer_config.json`, and the chosen ONNX weights into `.coraline/models/nomic-embed-text-v1.5/`.
+Downloads `tokenizer.json`, `tokenizer_config.json`, and the chosen ONNX weights into the shared model directory `~/.config/coraline/models/<model>/`.
 
-**Available variants (smallest to largest):**
+**`nomic-embed-text-v1.5` variants (smallest to largest):**
 
 | Variant | Size | Notes |
 |---|---|---|
@@ -437,10 +515,28 @@ Downloads `tokenizer.json`, `tokenizer_config.json`, and the chosen ONNX weights
 | `model_fp16.onnx` | ~274 MB | fp16 |
 | `model.onnx` | ~547 MB | full f32 |
 
+**`jina-embeddings-v2-base-code` variants:**
+
+| Variant | Size | Notes |
+|---|---|---|
+| `model_quantized.onnx` | ~162 MB | int8 quantized (recommended) |
+| `model_fp16.onnx` | ~321 MB | fp16 |
+| `model.onnx` | ~642 MB | full f32 |
+
+```bash
+coraline model download                                    # download vectors.model's default variant
+coraline model download --model jina-embeddings-v2-base-code
+```
+
 ### `coraline model status`
 
-Show which model files are present in the model directory.
+Show which model files are present in the model directory for the configured (or `--model`-selected) model.
+
+| Flag | Description |
+|---|---|
+| `--model NAME` | Which supported model to inspect (default: `vectors.model` from config.toml) |
 
 ```bash
 coraline model status
+coraline model status --model jina-embeddings-v2-base-code
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -50,8 +50,8 @@ auto_sync_interval_secs  = 120    # MCP background sync interval (0 = disabled)
 
 [vectors]
 enabled    = false                  # Requires ONNX model (see below)
-model      = "nomic-embed-text-v1.5"
-dimension  = 384
+model      = "nomic-embed-text-v1.5" # or "jina-embeddings-v2-base-code"
+dimension  = 768
 batch_size = 32
 ```
 
@@ -212,9 +212,7 @@ auto_sync_interval_secs = 60   # check every minute
 
 ## `[vectors]` Section
 
-Controls vector embedding generation for semantic search.
-
-> **Status:** Infrastructure is in place. Full semantic search with ONNX model embeddings is pending availability of a stable `ort` 2.0 API. Setting `enabled = true` currently has no effect.
+Controls vector embedding generation for semantic search (`coraline embed`, the `coraline_semantic_search` MCP tool). Requires a build with the `embeddings` or `embeddings-dynamic` feature.
 
 ### `enabled`
 
@@ -225,17 +223,22 @@ Enable vector embedding generation.
 
 ### `model`
 
-Embedding model identifier.
+Which embedding model to use. Run `coraline model list` to see every supported model with its dimension and description.
 
 - **Type:** string
-- **Default:** `"nomic-embed-text-v1.5"`
+- **Default:** `"nomic-embed-text-v1.5"` — general-purpose English text embeddings.
+- **Also supported:** `"jina-embeddings-v2-base-code"` — code-specialised embeddings, opt-in.
+
+Model files live in a shared directory (`~/.config/coraline/models/<model>/`, or `model_dir` below), not per-project — every project on the machine reuses the same downloaded weights for a given model. Run `coraline model download` (add `--model <name>` to target a non-default model) to fetch it.
+
+> **Switching models:** changing `model` on a project that already has embeddings does not retroactively re-embed existing nodes. Every read path (`coraline_semantic_search`, `coraline doctor`'s coverage probe, staleness checks) filters by the configured model, so a switch makes every node look unembedded for the *new* model until you re-run `coraline embed`. This is a real (if usually quick) re-embedding pass, not instant.
 
 ### `dimension`
 
-Embedding vector dimension. Must match the selected model.
+Embedding vector dimension. Must match the selected model — both currently supported models emit 768-dim vectors.
 
 - **Type:** integer
-- **Default:** `384`
+- **Default:** `768`
 
 ### `batch_size`
 
@@ -243,6 +246,25 @@ Number of symbols embedded per batch.
 
 - **Type:** integer
 - **Default:** `32`
+
+### `model_dir`
+
+Override the on-disk model directory. Unset by default — Coraline resolves it from `model` (`~/.config/coraline/models/<model>/`).
+
+- **Type:** string (path), optional
+
+### `model_file`
+
+Pin a specific ONNX filename instead of auto-detecting the best available variant for the configured `model`.
+
+- **Type:** string, optional
+
+### `max_seq_len`
+
+Maximum sequence length in tokens fed to the model.
+
+- **Type:** integer
+- **Default:** `512`
 
 ---
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # Coraline MCP Tools Reference
 
-Coraline exposes **29 MCP tools** when running as an MCP server (`coraline serve --mcp`).
+Coraline exposes **35 MCP tools** when running as an MCP server (`coraline serve --mcp`).
 All tool names are prefixed with `coraline_` to avoid collisions with other MCP servers.
 
 Protocol notes:
@@ -8,16 +8,7 @@ Protocol notes:
 - Expects `notifications/initialized` after `initialize` before normal requests
 - `tools/list` supports pagination via `cursor` and `nextCursor`
 
-`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in `.coraline/models/`. Run `coraline model download` then `coraline embed` to activate it. The remaining 28 tools are typically available; memory-backed tools may be skipped if their initialization fails (e.g. due to filesystem or permission issues).
-
-### Background Auto-Sync
-
-When the MCP server starts, it spawns a background thread that periodically checks index freshness and runs incremental sync when files have changed. This keeps the knowledge graph current without manual `coraline_sync` calls.
-
-- **Default interval:** 120 seconds (configurable via `sync.auto_sync_interval_secs` in `config.toml`)
-- **Disable:** Set `auto_sync_interval_secs = 0` in `[sync]`
-- When embeddings are enabled and an ONNX model is present, newly-added nodes are automatically embedded after each background sync
-- The background thread uses SQLite WAL mode for safe concurrent access alongside the main MCP request loop
+`coraline_semantic_search` is available by default (the `embeddings` feature ships enabled) but only registered when an ONNX model is present in the shared model directory (`~/.config/coraline/models/<model>/`, where `<model>` is `vectors.model` from config, default `nomic-embed-text-v1.5`). Run `coraline model download` then `coraline embed` to activate it — see `coraline model list` for every supported model. The remaining 34 tools are typically available; memory-backed tools may be skipped if their initialization fails (e.g. due to filesystem or permission issues).
 
 ---
 
@@ -37,6 +28,13 @@ When the MCP server starts, it spawns a background thread that periodically chec
 | | `coraline_get_symbols_overview` | List all symbols in a file |
 | | `coraline_find_references` | Find all references to a symbol |
 | | `coraline_node` | Get full node details and source code |
+| **Batch** | `coraline_batch_get_nodes` | Fetch multiple nodes by ID in one call |
+| | `coraline_batch_callers` | Get callers for multiple symbols in one call |
+| | `coraline_batch_callees` | Get callees for multiple symbols in one call |
+| **Advanced Search** | `coraline_search_by_signature` | Find symbols by type signature pattern |
+| | `coraline_search_by_docstring` | Find symbols by documentation/comment content |
+| | `coraline_search_exported_symbols` | Search only public/exported symbols |
+| | `coraline_find_by_kind_in_file` | Get all symbols of a kind in one file |
 | **Context** | `coraline_context` | Build structured context for an AI task |
 | **Audit** | `coraline_audit_docs` | Audit Markdown docs for stale references and undocumented exports |
 | **File** | `coraline_read_file` | Read file contents |
@@ -48,7 +46,6 @@ When the MCP server starts, it spawns a background thread that periodically chec
 | | `coraline_get_config` | Read project configuration |
 | | `coraline_update_config` | Update a config value |
 | | `coraline_semantic_search` | Vector similarity search (requires model download — see below) |
-| | `coraline_session_security_status` | Show live MCP session security counters and configured limits |
 | **Memory** | `coraline_write_memory` | Write or update a project memory |
 | | `coraline_read_memory` | Read a project memory |
 | | `coraline_list_memories` | List all memories |
@@ -365,6 +362,119 @@ Either `node_id` or `name` must be provided.
 
 ---
 
+## Batch Tools
+
+Fetch results for multiple symbols in one call instead of N round trips — roughly 60% fewer tokens than the equivalent sequence of single-symbol calls.
+
+### `coraline_batch_get_nodes`
+
+Fetch multiple nodes by ID in a single call.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `node_ids` | array of string | ✅ | — | Node IDs to fetch |
+| `include_body` | boolean | | `false` | Include source code body for each node |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+**Output:** `{ "nodes": [...], "count": N, "not_found": [...] }`
+
+---
+
+### `coraline_batch_callers`
+
+Get callers for multiple symbols in a single call.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `node_ids` | array of string | ✅ | — | Node IDs to find callers for |
+| `limit_per_node` | number | | `20` | Maximum callers to return per node |
+
+**Output:** `{ "callers": { "<node_id>": [...] }, "node_count": N }`
+
+---
+
+### `coraline_batch_callees`
+
+Get callees for multiple symbols in a single call.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `node_ids` | array of string | ✅ | — | Node IDs to find callees for |
+| `limit_per_node` | number | | `20` | Maximum callees to return per node |
+
+**Output:** `{ "callees": { "<node_id>": [...] }, "node_count": N }`
+
+---
+
+## Advanced Search Tools
+
+Specialized lookups over indexed nodes, faster than full-text `coraline_search` for these specific shapes — also roughly 60% fewer tokens for the matched use case.
+
+### `coraline_search_by_signature`
+
+Find symbols by type signature pattern (case-insensitive substring match) — e.g. functions by return type or parameters.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `pattern` | string | ✅ | — | Signature substring to search for (e.g. `"Result<"`, `"async fn"`, `"<T>"`) |
+| `kind` | string | | — | Filter: `function`, `method`, `class`, `struct`, `interface`, `trait` |
+| `limit` | number | | `20` | Maximum results |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
+### `coraline_search_by_docstring`
+
+Search symbols by documentation/comment content — find code by what it does, not just its name.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | ✅ | — | Text to search for in docstrings/comments |
+| `kind` | string | | — | Filter: `function`, `method`, `class`, `struct`, `interface`, `trait` |
+| `limit` | number | | `20` | Maximum results |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
+### `coraline_search_exported_symbols`
+
+Search only public/exported symbols — filters out internal implementation details to browse the public API surface.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | ✅ | — | Symbol name pattern; use `"*"` to list all |
+| `kind` | string | | — | Filter: `function`, `method`, `class`, `struct`, `interface`, `trait`, `module` |
+| `limit` | number | | `20` | Maximum results |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
+### `coraline_find_by_kind_in_file`
+
+Get all symbols of a specific kind in one file — fast file-scoped exploration.
+
+**Input:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `file_path` | string | ✅ | — | Path to the file (relative to project root) |
+| `kind` | string | ✅ | — | `function`, `method`, `class`, `struct`, `interface`, `trait`, `module`, `constant`, or `variable` |
+| `output_format` | string | | `"full"` | `"full"` or `"compact"` (65% token reduction) |
+
+---
+
 ## Context Tool
 
 ### `coraline_context`
@@ -520,45 +630,6 @@ Show project statistics: total files, nodes, edges, and unresolved reference cou
 
 ---
 
-### `coraline_session_security_status`
-
-Show live MCP session security counters and configured guardrail/session limits.
-Useful for runtime triage when investigating blocked or redacted tool calls.
-
-**Input:** None.
-
-**Example `tools/call` request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "sec-1",
-  "method": "tools/call",
-  "params": {
-    "name": "coraline_session_security_status",
-    "arguments": {}
-  }
-}
-```
-
-**Example `tools/call` response:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "sec-1",
-  "result": {
-    "content": [
-      {
-        "type": "text",
-        "text": "{\"session\":{\"tool_calls\":12,\"guardrail_hits\":3,\"blocked_calls\":1},\"limits\":{\"enabled\":true,\"max_tool_calls_per_session\":500,\"max_guardrail_hits_per_session\":100,\"max_blocked_calls_per_session\":25},\"security\":{\"enabled\":true,\"input_guardrail_mode\":\"monitor\",\"output_guardrail_mode\":\"enforce\"}}"
-      }
-    ],
-    "isError": false
-  }
-}
-```
-
----
-
 ### `coraline_get_config`
 
 Read the current project configuration from `.coraline/config.toml`.
@@ -604,14 +675,31 @@ Trigger an incremental sync of the index. Detects files added, modified, or remo
 
 ### `coraline_semantic_search`
 
-Search indexed nodes using natural-language vector similarity. Included in the default build; only registered as an MCP tool once an ONNX model is present in `.coraline/models/`. To activate:
+Search indexed nodes using natural-language vector similarity. Included in the default build; only registered as an MCP tool once an ONNX model is present in the shared model directory (`~/.config/coraline/models/<model>/`, `<model>` from `vectors.model`). To activate:
 
 ```bash
-coraline model download   # download nomic-embed-text-v1.5 (~137 MB)
+coraline model download   # download the configured model (default nomic-embed-text-v1.5, ~137 MB)
 coraline embed            # generate embeddings for all indexed nodes
 ```
 
-When this tool is used, Coraline periodically performs a throttled freshness check. If indexed state is stale it runs incremental sync automatically, then refreshes stale/missing embeddings before search.
+Run `coraline model list` to see every supported model, including the code-specialised `jina-embeddings-v2-base-code`.
+
+When this tool is used, Coraline periodically performs a throttled freshness check. If indexed state is stale it runs incremental sync automatically, then refreshes stale/missing embeddings before search. Results and coverage are scoped to whichever model is currently configured — embeddings from a previously-configured model are ignored, not mixed in.
+
+**Structured error when the model is missing:**
+
+If the ONNX model can't be loaded (not downloaded yet, or `tokenizer.json`/weights missing), the tool call fails with `isError: true` and a structured `EMBEDDING_MODEL_MISSING` envelope in `structuredContent`, so an agent can branch on `code` instead of parsing free-form text:
+
+```json
+{
+  "code": "EMBEDDING_MODEL_MISSING",
+  "message": "Embedding model is not present. Run `coraline model download` to download it.",
+  "recover": {
+    "command": "coraline model download",
+    "docs": "https://github.com/greysquirr3l/coraline#embeddings (debug: load failed: ...)"
+  }
+}
+```
 
 **Input:**
 


### PR DESCRIPTION
## Summary

Ships as v0.12.0. Combines the branch's original doctor/model-validation work with follow-on multi-model embedding support, structured MCP errors, and a couple of tool regressions found and fixed along the way.

- **`coraline doctor`** — diagnostic subcommand (config/db/hooks/model/embed-coverage checks), `--quick`/`--json` modes, CI-friendly exit codes.
- **`coraline init --embed/--no-embed/--yes`** — non-interactive control over the post-init model download decision.
- **`coraline status`** embedding-model line (model name, file, directory).
- **Multi-model embeddings** — `vectors.model` now actually selects the embedding model (previously present in config but unused). Ships `nomic-embed-text-v1.5` (default) and `jina-embeddings-v2-base-code` (opt-in, code-specialised). New `coraline model list`; `--model` flag on `download`/`status`. Fixed a real bug where `VectorManager` always tagged stored embeddings with the default model name regardless of which model was actually loaded. Coverage/staleness/search queries now filter by the `vectors.model` column so switching models is self-healing.
- **Structured `EMBEDDING_MODEL_MISSING` MCP error** — typed `code`/`message`/`recover` envelope in `structuredContent` instead of free-form text.
- **Restored `coraline_audit_docs`, `coraline_find_file` (MCP) and `coraline audit-docs` (CLI)** — an earlier refactor (`b079ac5`) silently dropped their registration while leaving the implementations in place. Re-wired.
- **Docs reconciled against ground truth** — `docs/MCP_TOOLS.md`/book mirror now list all 35 actually-registered tools (verified by diff against the live registry), including previously-undocumented batch/advanced-search tool groups. Removed two phantom/dead doc sections (`coraline_session_security_status`, "Background Auto-Sync") that describe functionality no longer present in the current `McpServer` — flagged as separate follow-ups, not restored here.
- **Lint sweep** — replaced blanket `#[allow(clippy::...)]` suppressions with real fixes or justified `#[expect(..., reason = "...")]`, per project convention.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo lint` (zero new `#[allow(clippy::...)]`)
- [x] `cargo fmt --check`
- [x] `cargo test --all-features` (118 passed, 1 pre-existing ignore requiring a real ONNX model on disk)
- [x] Manual smoke test against a real model directory: `coraline model list/status`, `coraline doctor --json` (all probes green), `coraline embed` (vectors table correctly tagged with model name), `coraline_semantic_search` over MCP (real results, real similarity scores)
- [x] Manual smoke test of restored tools: `coraline audit-docs` CLI, `coraline_audit_docs`/`coraline_find_file` present in MCP `tools/list`