### PR TITLE
fix(release): pass release-notes body via env var, not spliced into shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,11 +357,21 @@ jobs:
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed via env (not spliced directly into the script below) so
+          # that release-notes content is never interpreted as shell syntax.
+          # GitHub Actions substitutes `${{ }}` as literal text *before*
+          # bash parses the script; a changelog entry containing backticks
+          # (e.g. `coraline doctor`) would otherwise be executed as command
+          # substitution — even inside double quotes — instead of treated
+          # as inert string content.
+          RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+          RELEASE_SHA: ${{ needs.resolve-tag.outputs.sha }}
+          RELEASE_BODY: ${{ steps.changelog.outputs.notes }}
         run: |
           set -euo pipefail
-          TAG="${{ needs.resolve-tag.outputs.tag }}"
-          SHA="${{ needs.resolve-tag.outputs.sha }}"
-          BODY="${{ steps.changelog.outputs.notes }}"
+          TAG="$RELEASE_TAG"
+          SHA="$RELEASE_SHA"
+          BODY="$RELEASE_BODY"
           PRERELEASE_FLAG=""
           if [[ "$TAG" == *-alpha* || "$TAG" == *-beta* || "$TAG" == *-rc* ]]; then
             PRERELEASE_FLAG="--prerelease"


### PR DESCRIPTION
## Summary

`release.yml`'s "Create or update GitHub Release" step did `BODY="${{ steps.changelog.outputs.notes }}"` directly in the `run:` script. GitHub Actions substitutes `${{ }}` expressions as literal text *before* bash parses the script, so any changelog entry containing shell metacharacters gets executed rather than treated as a string — backticks in particular (completely normal Markdown inline-code formatting) are interpreted as command substitution even inside double quotes, since the substitution happens at text-splicing time, not as bash variable expansion.

This broke the v0.12.0 release: the CHANGELOG entry's inline-code formatting (`` `coraline doctor` ``, `` `vectors.model` ``, etc.) caused the script to try executing those as commands, ending in "File name too long" / exit 126 — **after** crates.io publish had already succeeded, so this step never attached binaries or set the correct release body. I completed that release manually (tag, GitHub release, body, binaries) outside this fix.

Fixed by passing `TAG`/`SHA`/`BODY` through `env:` (GitHub Actions' supported mechanism for safely getting untrusted-shaped values into a script) and referencing them as normal shell variables — their content is real env-var data by the time bash sees it, so quoting works as expected and backticks are inert.

## Test plan

- [x] Manually verified the failure mode against the actual v0.12.0 CHANGELOG entry (reproduced the exact `command not found` cascade)
- [ ] Next real release will exercise this step end-to-end; no automated test for this workflow step exists